### PR TITLE
Hopkins contact model

### DIFF
--- a/src/GRANULAR/pair_gran_hertz_history.cpp
+++ b/src/GRANULAR/pair_gran_hertz_history.cpp
@@ -36,7 +36,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 PairGranHertzHistory::PairGranHertzHistory(LAMMPS *lmp) :
-  PairGranHookeHistory(lmp) {}
+  PairGranHookeHistory(lmp) {
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/GRANULAR/pair_gran_hooke_history.cpp
+++ b/src/GRANULAR/pair_gran_hooke_history.cpp
@@ -39,8 +39,8 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-PairGranHookeHistory::PairGranHookeHistory(LAMMPS *lmp, int _size_history, int _fullflag) : Pair(lmp),
-  size_history(_size_history), fullflag(_fullflag)
+PairGranHookeHistory::PairGranHookeHistory(LAMMPS *lmp, int _size_history) : Pair(lmp),
+  size_history(_size_history)
 {
   single_enable = 1;
   no_virial_fdotr_compute = 1;
@@ -58,6 +58,9 @@ PairGranHookeHistory::PairGranHookeHistory(LAMMPS *lmp, int _size_history, int _
   // set comm size needed by this Pair if used with fix rigid
 
   comm_forward = 1;
+
+  nondefault_history_transfer = 0;
+  beyond_contact = 0;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -78,6 +81,8 @@ PairGranHookeHistory::~PairGranHookeHistory()
   }
 
   memory->destroy(mass_rigid);
+
+  int nondefault_history_transfer = 0;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -406,10 +411,6 @@ void PairGranHookeHistory::init_style()
 
   int irequest = neighbor->request(this,instance_me);
   neighbor->requests[irequest]->size = 1;
-  if (fullflag){
-    neighbor->requests[irequest]->half = 0;
-    neighbor->requests[irequest]->full = 1;
-  }
   if (history) neighbor->requests[irequest]->history = 1;
 
   dt = update->dt;

--- a/src/GRANULAR/pair_gran_hooke_history.h
+++ b/src/GRANULAR/pair_gran_hooke_history.h
@@ -26,7 +26,7 @@ namespace LAMMPS_NS {
 
 class PairGranHookeHistory : public Pair {
  public:
-  PairGranHookeHistory(class LAMMPS *, int _size_history=3, int fullflag = 0);
+  PairGranHookeHistory(class LAMMPS *, int _size_history=3);
   virtual ~PairGranHookeHistory();
   virtual void compute(int, int);
   virtual void settings(int, char **);
@@ -43,6 +43,12 @@ class PairGranHookeHistory : public Pair {
   void unpack_forward_comm(int, int, double *);
   double memory_usage();
 
+  int nondefault_history_transfer; //By default set to 0, meaning history[i][j] = -history[j][i].
+    // Otherwise set to 1, and provide a transfer_history function.
+  virtual void transfer_history(double*, double*) {};
+
+  int beyond_contact; //0 is interactions are only when particles are in contact, 1 otherwise
+
  protected:
   double kn,kt,gamman,gammat,xmu;
   int dampflag;
@@ -50,7 +56,6 @@ class PairGranHookeHistory : public Pair {
   int freeze_group_bit;
   int history;
   int size_history;
-  int fullflag;
 
   int neighprev;
   double *onerad_dynamic,*onerad_frozen;

--- a/src/USER-DEMSI/pair_gran_hopkins.cpp
+++ b/src/USER-DEMSI/pair_gran_hopkins.cpp
@@ -404,11 +404,8 @@ void PairGranHopkins::compute_bonded(double *history, int* touch, int i, int j){
   Fnmag = nprefac*(Dn*chidiff + Cn*chidiff2);
   Ftmag = sprefac*(Dt*chidiff + Ct*chidiff2);
   Nn = nprefac*(An*Cn*chidiff3 + (Bn*Cn+An*Dn)*chidiff2 + Bn*Dn*chidiff);
-  Nt = Bt*Ftmag; //sprefac*(Bt*Ct*chidiff2 + Bt*Dt*chidiff);
+  Nt = Bt*Ftmag;
 
-  if (i==DEBUGID_1 && j == DEBUGID_2 && update->ntimestep >= DEBUG_TIMESTEP){
-  //  printf("Distance is %f, radsum is %g\n",sqrt((x[i][0]-x[j][0])*(x[i][0]-x[j][0])+(x[i][1]-x[j][1])*(x[i][1]-x[j][1])), atom->radius[i]+atom->radius[j]);
-  }
   //Damping force
   area_bond = history[10]*history[11]*chidiff;
   damp_prefac = damp_bonded*area_bond;
@@ -425,11 +422,6 @@ void PairGranHopkins::compute_bonded(double *history, int* touch, int i, int j){
   fx = Fnmag*bex + Ftmag*mex;
   fy = Fnmag*bey + Ftmag*mey;
 
-//  if (update->ntimestep > 10){
-//    printf("%d %d %g %g %g %g\n",i,j,fx,fy,fdampx,fdampy);
-//  }
-//  //Damping must not cause force to flip sign
- // printf("%d %d %g %g %g %g \n",i,j,fx,fy,fdampx,fdampy);
   if (fx < 0 && fdampx > 0){
     fx = MIN(fx+fdampx, 0);
   }
@@ -451,7 +443,6 @@ void PairGranHopkins::compute_bonded(double *history, int* touch, int i, int j){
 
   torque[i][2] += Nn + Nt + torquedamp;
 
-  //printf("%d %d %g %g %g %g\n",i,j,Nn,Nt,Nn+Nt,torquedamp);
   if (force->newton_pair || j < atom->nlocal){
     f[j][0] -= fx;
     f[j][1] -= fy;
@@ -465,14 +456,13 @@ void PairGranHopkins::compute_bonded(double *history, int* touch, int i, int j){
 
     Nnj = nprefac*(An*Cnj*chidiff3 + (Bnj*Cnj+An*Dnj)*chidiff2 + Bnj*Dnj*chidiff);
     Ntj = -Btj*Ftmag;
-    //printf("%d %d %g %g %g %g\n",i,j,Nnj,Ntj,Nnj+Ntj,torquedamp);
     torque[j][2] += Nnj + Ntj - torquedamp;
   }
 
   //Update chi1, chi2
   hmin = MIN(atom->min_thickness[i], atom->min_thickness[j]);
   if (historyupdate){
-    //update_chi(kn, kt, Dn, Cn, Dt, Ct, hmin, history[8], history[9]);
+    update_chi(kn, kt, Dn, Cn, Dt, Ct, hmin, history[8], history[9]);
     *touch = 1;
     if (history[8] >= history[9]){ //Bond just broke
         double dx = x[i][0] - x[j][0];

--- a/src/USER-DEMSI/pair_gran_hopkins.h
+++ b/src/USER-DEMSI/pair_gran_hopkins.h
@@ -32,7 +32,7 @@ public:
   void settings(int, char **);
   double single(int, int, int, int, double, double, double, double &);
 private:
-  void compute_bonded(double*, int, int);
+  void compute_bonded(double*, int*, int, int);
   void compute_nonbonded(double*, int*, int, int);
   void update_chi(double, double, double, double, double, double, double, double&, double&);
 

--- a/src/USER-DEMSI/pair_gran_hopkins.h
+++ b/src/USER-DEMSI/pair_gran_hopkins.h
@@ -31,6 +31,8 @@ public:
   virtual void compute(int, int);
   void settings(int, char **);
   double single(int, int, int, int, double, double, double, double &);
+  virtual void transfer_history(double*, double*);
+  double init_one(int, int);
 private:
   void compute_bonded(double*, int*, int, int);
   void compute_nonbonded(double*, int*, int, int);

--- a/src/fix_neigh_history.cpp
+++ b/src/fix_neigh_history.cpp
@@ -602,7 +602,8 @@ void FixNeighHistory::post_neighbor()
 
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];
-      rflag = sbmask(j);
+      //rflag = sbmask(j);
+      rflag = 1;
       j &= NEIGHMASK;
       jlist[jj] = j;
 
@@ -610,10 +611,10 @@ void FixNeighHistory::post_neighbor()
       // preserve neigh history info if tag[j] is in old-neigh partner list
       // this test could be more geometrically precise for two sphere/line/tri
 
-      if (rflag) {
+      if (rflag){
         jtag = tag[j];
         for (m = 0; m < np; m++)
-          if (partner[i][m] == jtag) break;
+          if (partner[i][m] == jtag) break;       
         if (m < np) {
           allflags[jj] = 1;
           memcpy(&allvalues[nn],&valuepartner[i][dnum*m],dnumbytes);

--- a/src/fix_neigh_history.cpp
+++ b/src/fix_neigh_history.cpp
@@ -406,7 +406,8 @@ void FixNeighHistory::pre_exchange_newton()
         m = npartner[j]++;
         partner[j][m] = tag[i];
         jvalues = &valuepartner[j][dnum*m];
-        for (n = 0; n < dnum; n++) jvalues[n] = -onevalues[n];
+        if (pair->nondefault_history_transfer) pair->transfer_history(onevalues, jvalues);
+        else for (n = 0; n < dnum; n++) jvalues[n] = -onevalues[n];
       }
     }
   }
@@ -518,7 +519,8 @@ void FixNeighHistory::pre_exchange_no_newton()
           m = npartner[j]++;
           partner[j][m] = tag[i];
           jvalues = &valuepartner[j][dnum*m];
-          for (n = 0; n < dnum; n++) jvalues[n] = -onevalues[n];
+          if (pair->nondefault_history_transfer) pair->transfer_history(onevalues, jvalues);
+          else for (n = 0; n < dnum; n++) jvalues[n] = -onevalues[n];
         }
       }
     }
@@ -602,8 +604,8 @@ void FixNeighHistory::post_neighbor()
 
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];
-      //rflag = sbmask(j);
-      rflag = 1;
+      rflag = sbmask(j);
+      if (pair->beyond_contact) rflag = 1;
       j &= NEIGHMASK;
       jlist[jj] = j;
 
@@ -721,7 +723,7 @@ int FixNeighHistory::pack_reverse_comm_size(int n, int first)
   last = first + n;
 
   for (i = first; i < last; i++)
-    m += 1 + 4*npartner[i];
+    m += 1 + (dnum+1)*npartner[i];
 
   return m;
 }

--- a/src/fix_neigh_history.cpp
+++ b/src/fix_neigh_history.cpp
@@ -415,7 +415,7 @@ void FixNeighHistory::pre_exchange_newton()
   // perform reverse comm to augment
   // owned atom partner/valuepartner with ghost info
   // use variable variant b/c size of packed data can be arbitrarily large
-  //   if many touching neighbors for large particle
+  //  if many touching neighbors for large particle
 
   commflag = PERPARTNER;
   comm->reverse_comm_fix_variable(this);

--- a/src/fix_neigh_history.h
+++ b/src/fix_neigh_history.h
@@ -22,6 +22,7 @@ FixStyle(NEIGH_HISTORY,FixNeighHistory)
 
 #include "fix.h"
 #include "my_page.h"
+#include "pair_gran_hooke_history.h"
 
 namespace LAMMPS_NS {
 
@@ -31,7 +32,7 @@ class FixNeighHistory : public Fix {
   int nall_neigh;               // ditto for nlocal+nghost
   int **firstflag;              // ptr to each atom's neighbor flsg
   double **firstvalue;          // ptr to each atom's values
-  class Pair *pair;             // ptr to pair style that uses neighbor history
+  class PairGranHookeHistory *pair;             // ptr to pair style that uses neighbor history
 
   FixNeighHistory(class LAMMPS *, int, char **);
   ~FixNeighHistory();


### PR DESCRIPTION
Fixed a few bugs in Hopkins contact model implementation (particularly, bonded contacts):
- an algebra error in the torque formulation that caused significant issues
- j-i torque calculation was conceptually incorrect, should be fixed now

This isn't thoroughly tested by any means, and there are still issues that need to be worked out with transferring contact history following re-neighboring, transitioning from bonded to nonbonded, etc.