### PR TITLE
Generalized Hopkins contact model

### DIFF
--- a/src/USER-DEMSI/pair_gran_hopkins.h
+++ b/src/USER-DEMSI/pair_gran_hopkins.h
@@ -41,6 +41,8 @@ private:
   int history_ndim;
   double Emod, poiss, sig_c0, sig_t0, phi, damp_bonded, damp_tangential, damp_normal, tanphi, friction_tangential, hprime_0;
   double Gmod;
+  char sig_c0_type[256];
+  char sig_t0_type[256];
 };
 
 }


### PR DESCRIPTION
Generalized Hopkins contact model so different types of fracture parameters can be input

## Purpose

This generalizes the interface of the Hopkins contact model so that different types of failure parameters may be input. This adds an option for constant fracture stresses as well as the current Hopkins like ones.

## Author(s)

Adrian K. Turner, Los Alamos National Laboratory

## Backward Compatibility

Backwards compatible.

## Implementation Notes

Verified in the DEMSI model

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links


