### PR TITLE
Semi-implicit integration

### DIFF
--- a/src/USER-DEMSI/atom_vec_demsi.h
+++ b/src/USER-DEMSI/atom_vec_demsi.h
@@ -13,7 +13,7 @@
 
 #ifdef ATOM_CLASS
 
-AtomStyle(demsi,AtomVecDemsi)
+AtomStyle(demsi, AtomVecDemsi)
 
 #else
 
@@ -75,16 +75,20 @@ class AtomVecDemsi : public AtomVec {
   double **x,**v,**f;
   double *radius,*rmass;
   double **omega,**torque;
-  double **forcing;
-  double *mean_thickness;
-  double *min_thickness;
+double ** forcing;
+double * mean_thickness;
+double * min_thickness;
+double * ice_area;
+double * coriolis;
+double ** ocean_vel;
+double ** bvector;
   int radvary;
-
-  int **nspecial;
-  tagint **special;
-  int *num_bond;
-  int **bond_type;
-  tagint **bond_atom;
+int **nspecial;
+tagint **special;
+int *num_bond;
+int **bond_type;
+tagint **bond_atom
+;
 };
 
 }

--- a/src/USER-DEMSI/fix_nve_sphere_demsi.cpp
+++ b/src/USER-DEMSI/fix_nve_sphere_demsi.cpp
@@ -48,6 +48,11 @@ FixNVESphereDemsi::FixNVESphereDemsi(LAMMPS *lmp, int narg, char **arg) :
 
 
   int iarg = 3;
+  if (narg < 5){
+    error->all(FLERR,"Fix nve/sphere/demsi requires additional parameters");
+  }
+  ocean_density = force->numeric(FLERR, arg[3]);
+  ocean_drag = force->numeric(FLERR, arg[4]);
   /*while (iarg < narg) {
     if (strcmp(arg[iarg],"update") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix nve/sphere command");
@@ -73,8 +78,6 @@ FixNVESphereDemsi::FixNVESphereDemsi(LAMMPS *lmp, int narg, char **arg) :
     error->all(FLERR,"Fix nve/sphere demsi requires 2d simulation");
   if (!atom->sphere_flag)
     error->all(FLERR,"Fix nve/sphere requires atom style sphere");
-  if (extra == DIPOLE && !atom->mu_flag)
-    error->all(FLERR,"Fix nve/sphere update dipole requires atom attribute mu");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -148,13 +151,13 @@ void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
       vel_diff = sqrt((wind_vel_x[i]-v[i][0])*(wind_vel_x[i]-v[i][0]) +
           (wind_vel_y[i]-v[i][1])*(wind_vel_y[i]-v[i][1]));
       D = ice_area[i]*ocean_drag*ocean_density*vel_diff;
-      m_prime = rmass[i]/update->dt*0.5;
+      m_prime = rmass[i]/(update->dt*0.5);
       a00 = a11 = m_prime+D;
       a10 = rmass[i]*coriolis[i];
       a01 = -a10;
 
       b0 = m_prime*v[i][0] + f[i][0] + bx[i] + D*wind_vel_x[i];
-      b1 = m_prime*v[i][1] + f[i][1] + by[i] + D*wind_vel_x[i];
+      b1 = m_prime*v[i][1] + f[i][1] + by[i] + D*wind_vel_y[i];
 
       detinv = 1.0/(a00*a11 - a01*a10);
       v[i][0] = detinv*( a11*b0 - a01*b1);
@@ -216,13 +219,13 @@ void FixNVESphereDemsi::final_integrate()
       vel_diff = sqrt((wind_vel_x[i]-v[i][0])*(wind_vel_x[i]-v[i][0]) +
           (wind_vel_y[i]-v[i][1])*(wind_vel_y[i]-v[i][1]));
       D = ice_area[i]*ocean_drag*ocean_density*vel_diff;
-      m_prime = rmass[i]/update->dt*0.5;
+      m_prime = rmass[i]/(update->dt*0.5);
       a00 = a11 = m_prime+D;
       a10 = rmass[i]*coriolis[i];
       a01 = -a10;
 
       b0 = m_prime*v[i][0] + f[i][0] + bx[i] + D*wind_vel_x[i];
-      b1 = m_prime*v[i][1] + f[i][1] + by[i] + D*wind_vel_x[i];
+      b1 = m_prime*v[i][1] + f[i][1] + by[i] + D*wind_vel_y[i];
 
       detinv = 1.0/(a00*a11 - a01*a10);
       v[i][0] = detinv*( a11*b0 - a01*b1);

--- a/src/USER-DEMSI/fix_nve_sphere_demsi.cpp
+++ b/src/USER-DEMSI/fix_nve_sphere_demsi.cpp
@@ -96,8 +96,8 @@ void FixNVESphereDemsi::init()
   int flag;
   ice_area_index = atom->find_custom("ice_area", flag);
   coriolis_index = atom->find_custom("coriolis", flag);
-  wind_vel_x_index = atom->find_custom("wind_vel_x", flag);
-  wind_vel_y_index = atom->find_custom("wind_vel_y", flag);
+  ocean_vel_x_index = atom->find_custom("ocean_vel_x", flag);
+  ocean_vel_y_index = atom->find_custom("ocean_vel_y", flag);
   bx_index = atom->find_custom("bx", flag);
   by_index = atom->find_custom("by", flag);
 
@@ -122,8 +122,8 @@ void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
   double *rmass = atom->rmass;
   double *ice_area = atom->dvector[ice_area_index];
   double *coriolis = atom->dvector[coriolis_index];
-  double *wind_vel_x = atom->dvector[wind_vel_x_index];
-  double *wind_vel_y = atom->dvector[wind_vel_y_index];
+  double *ocean_vel_x = atom->dvector[ocean_vel_x_index];
+  double *ocean_vel_y = atom->dvector[ocean_vel_y_index];
   double *bx = atom->dvector[bx_index];
   double *by = atom->dvector[by_index];
 
@@ -148,16 +148,16 @@ void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
     if (mask[i] & groupbit) {
       dtfm = dtf / rmass[i];
 
-      vel_diff = sqrt((wind_vel_x[i]-v[i][0])*(wind_vel_x[i]-v[i][0]) +
-          (wind_vel_y[i]-v[i][1])*(wind_vel_y[i]-v[i][1]));
+      vel_diff = sqrt((ocean_vel_x[i]-v[i][0])*(ocean_vel_x[i]-v[i][0]) +
+          (ocean_vel_y[i]-v[i][1])*(ocean_vel_y[i]-v[i][1]));
       D = ice_area[i]*ocean_drag*ocean_density*vel_diff;
-      m_prime = rmass[i]/(update->dt*0.5);
+      m_prime = rmass[i]/dtf;
       a00 = a11 = m_prime+D;
       a10 = rmass[i]*coriolis[i];
       a01 = -a10;
 
-      b0 = m_prime*v[i][0] + f[i][0] + bx[i] + D*wind_vel_x[i];
-      b1 = m_prime*v[i][1] + f[i][1] + by[i] + D*wind_vel_y[i];
+      b0 = m_prime*v[i][0] + f[i][0] + bx[i] + D*ocean_vel_x[i];
+      b1 = m_prime*v[i][1] + f[i][1] + by[i] + D*ocean_vel_y[i];
 
       detinv = 1.0/(a00*a11 - a01*a10);
       v[i][0] = detinv*( a11*b0 - a01*b1);
@@ -188,8 +188,8 @@ void FixNVESphereDemsi::final_integrate()
   double *rmass = atom->rmass;
   double *ice_area = atom->dvector[ice_area_index];
   double *coriolis = atom->dvector[coriolis_index];
-  double *wind_vel_x = atom->dvector[wind_vel_x_index];
-  double *wind_vel_y = atom->dvector[wind_vel_y_index];
+  double *ocean_vel_x = atom->dvector[ocean_vel_x_index];
+  double *ocean_vel_y = atom->dvector[ocean_vel_y_index];
   double *bx = atom->dvector[bx_index];
   double *by = atom->dvector[by_index];
 
@@ -216,16 +216,16 @@ void FixNVESphereDemsi::final_integrate()
     if (mask[i] & groupbit) {
       dtfm = dtf / rmass[i];
 
-      vel_diff = sqrt((wind_vel_x[i]-v[i][0])*(wind_vel_x[i]-v[i][0]) +
-          (wind_vel_y[i]-v[i][1])*(wind_vel_y[i]-v[i][1]));
+      vel_diff = sqrt((ocean_vel_x[i]-v[i][0])*(ocean_vel_x[i]-v[i][0]) +
+          (ocean_vel_y[i]-v[i][1])*(ocean_vel_y[i]-v[i][1]));
       D = ice_area[i]*ocean_drag*ocean_density*vel_diff;
-      m_prime = rmass[i]/(update->dt*0.5);
+      m_prime = rmass[i]/dtf;
       a00 = a11 = m_prime+D;
       a10 = rmass[i]*coriolis[i];
       a01 = -a10;
 
-      b0 = m_prime*v[i][0] + f[i][0] + bx[i] + D*wind_vel_x[i];
-      b1 = m_prime*v[i][1] + f[i][1] + by[i] + D*wind_vel_y[i];
+      b0 = m_prime*v[i][0] + f[i][0] + bx[i] + D*ocean_vel_x[i];
+      b1 = m_prime*v[i][1] + f[i][1] + by[i] + D*ocean_vel_y[i];
 
       detinv = 1.0/(a00*a11 - a01*a10);
       v[i][0] = detinv*( a11*b0 - a01*b1);

--- a/src/USER-DEMSI/fix_nve_sphere_demsi.cpp
+++ b/src/USER-DEMSI/fix_nve_sphere_demsi.cpp
@@ -1,0 +1,239 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include "fix_nve_sphere_demsi.h"
+#include "atom.h"
+#include "domain.h"
+#include "atom_vec.h"
+#include "update.h"
+#include "respa.h"
+#include "force.h"
+#include "error.h"
+#include "math_vector.h"
+#include "math_extra.h"
+
+using namespace LAMMPS_NS;
+using namespace FixConst;
+using namespace MathExtra;
+
+enum{NONE,DIPOLE};
+enum{NODLM,DLM};
+
+/* ---------------------------------------------------------------------- */
+
+FixNVESphereDemsi::FixNVESphereDemsi(LAMMPS *lmp, int narg, char **arg) :
+  FixNVE(lmp, narg, arg)
+{
+  if (narg < 3) error->all(FLERR,"Illegal fix nve/sphere/demsi command");
+
+  time_integrate = 1;
+
+  // process extra keywords
+  // inertia = moment of inertia prefactor for sphere or disc
+
+  inertia = 0.5;
+
+
+  int iarg = 3;
+  /*while (iarg < narg) {
+    if (strcmp(arg[iarg],"update") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix nve/sphere command");
+      if (strcmp(arg[iarg+1],"dipole") == 0) extra = DIPOLE;
+      else if (strcmp(arg[iarg+1],"dipole/dlm") == 0) {
+        extra = DIPOLE;
+        dlm = DLM;
+      } else error->all(FLERR,"Illegal fix nve/sphere command");
+      iarg += 2;
+    }
+    else if (strcmp(arg[iarg],"disc")==0) {
+      inertia = 0.5;
+      if (domain->dimension != 2)
+        error->all(FLERR,"Fix nve/sphere disc requires 2d simulation");
+      iarg++;
+    }
+    else error->all(FLERR,"Illegal fix nve/sphere command");
+  }*/
+
+  // error checks
+
+  if (domain->dimension != 2)
+    error->all(FLERR,"Fix nve/sphere demsi requires 2d simulation");
+  if (!atom->sphere_flag)
+    error->all(FLERR,"Fix nve/sphere requires atom style sphere");
+  if (extra == DIPOLE && !atom->mu_flag)
+    error->all(FLERR,"Fix nve/sphere update dipole requires atom attribute mu");
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixNVESphereDemsi::init()
+{
+  FixNVE::init();
+
+  // check that all particles are finite-size spheres
+  // no point particles allowed
+
+  double *radius = atom->radius;
+  int *mask = atom->mask;
+  int nlocal = atom->nlocal;
+
+  int flag;
+  ice_area_index = atom->find_custom("ice_area", flag);
+  coriolis_index = atom->find_custom("coriolis", flag);
+  wind_vel_x_index = atom->find_custom("wind_vel_x", flag);
+  wind_vel_y_index = atom->find_custom("wind_vel_y", flag);
+  bx_index = atom->find_custom("bx", flag);
+  by_index = atom->find_custom("by", flag);
+
+  for (int i = 0; i < nlocal; i++)
+    if (mask[i] & groupbit)
+      if (radius[i] == 0.0)
+        error->one(FLERR,"Fix nve/sphere requires extended particles");
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
+{
+  double dtfm;
+
+  double **x = atom->x;
+  double **v = atom->v;
+  double **f = atom->f;
+  double **omega = atom->omega;
+  double **torque = atom->torque;
+  double *radius = atom->radius;
+  double *rmass = atom->rmass;
+  double *ice_area = atom->dvector[ice_area_index];
+  double *coriolis = atom->dvector[coriolis_index];
+  double *wind_vel_x = atom->dvector[wind_vel_x_index];
+  double *wind_vel_y = atom->dvector[wind_vel_y_index];
+  double *bx = atom->dvector[bx_index];
+  double *by = atom->dvector[by_index];
+
+  double D, vel_diff, m_prime;
+  double a00, a01, a10, a11;
+  double detinv;
+  double b0, b1;
+  double det;
+
+  int *mask = atom->mask;
+  int nlocal = atom->nlocal;
+  if (igroup == atom->firstgroup) nlocal = atom->nfirst;
+
+  // set timestep here since dt may have changed or come via rRESPA
+
+  double dtfrotate = dtf / inertia;
+  double dtirotate;
+  // update v,x,omega for all particles
+  // d_omega/dt = torque / inertia
+
+  for (int i = 0; i < nlocal; i++) {
+    if (mask[i] & groupbit) {
+      dtfm = dtf / rmass[i];
+
+      vel_diff = sqrt((wind_vel_x[i]-v[i][0])*(wind_vel_x[i]-v[i][0]) +
+          (wind_vel_y[i]-v[i][1])*(wind_vel_y[i]-v[i][1]));
+      D = ice_area[i]*ocean_drag*ocean_density*vel_diff;
+      m_prime = rmass[i]/update->dt*0.5;
+      a00 = a11 = m_prime+D;
+      a10 = rmass[i]*coriolis[i];
+      a01 = -a10;
+
+      b0 = m_prime*v[i][0] + f[i][0] + bx[i] + D*wind_vel_x[i];
+      b1 = m_prime*v[i][1] + f[i][1] + by[i] + D*wind_vel_x[i];
+
+      detinv = 1.0/(a00*a11 - a01*a10);
+      v[i][0] = detinv*( a11*b0 - a01*b1);
+      v[i][1] = detinv*(-a10*b0 + a00*b1);
+
+      x[i][0] += dtv * v[i][0];
+      x[i][1] += dtv * v[i][1];
+      x[i][2] += dtv * v[i][2];
+
+      dtirotate = dtfrotate / (radius[i]*radius[i]*rmass[i]);
+      omega[i][0] += dtirotate * torque[i][0];
+      omega[i][1] += dtirotate * torque[i][1];
+      omega[i][2] += dtirotate * torque[i][2];
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixNVESphereDemsi::final_integrate()
+{
+  double dtfm,dtirotate;
+
+  double **v = atom->v;
+  double **f = atom->f;
+  double **omega = atom->omega;
+  double **torque = atom->torque;
+  double *rmass = atom->rmass;
+  double *ice_area = atom->dvector[ice_area_index];
+  double *coriolis = atom->dvector[coriolis_index];
+  double *wind_vel_x = atom->dvector[wind_vel_x_index];
+  double *wind_vel_y = atom->dvector[wind_vel_y_index];
+  double *bx = atom->dvector[bx_index];
+  double *by = atom->dvector[by_index];
+
+  double *radius = atom->radius;
+  int *mask = atom->mask;
+  int nlocal = atom->nlocal;
+  if (igroup == atom->firstgroup) nlocal = atom->nfirst;
+
+  double D, vel_diff, m_prime;
+  double a00, a01, a10, a11;
+  double detinv;
+  double b0, b1;
+  double det;
+
+  // set timestep here since dt may have changed or come via rRESPA
+
+  double dtfrotate = dtf / inertia;
+
+  // update v,omega for all particles
+  // d_omega/dt = torque / inertia
+
+  double rke = 0.0;
+  for (int i = 0; i < nlocal; i++)
+    if (mask[i] & groupbit) {
+      dtfm = dtf / rmass[i];
+
+      vel_diff = sqrt((wind_vel_x[i]-v[i][0])*(wind_vel_x[i]-v[i][0]) +
+          (wind_vel_y[i]-v[i][1])*(wind_vel_y[i]-v[i][1]));
+      D = ice_area[i]*ocean_drag*ocean_density*vel_diff;
+      m_prime = rmass[i]/update->dt*0.5;
+      a00 = a11 = m_prime+D;
+      a10 = rmass[i]*coriolis[i];
+      a01 = -a10;
+
+      b0 = m_prime*v[i][0] + f[i][0] + bx[i] + D*wind_vel_x[i];
+      b1 = m_prime*v[i][1] + f[i][1] + by[i] + D*wind_vel_x[i];
+
+      detinv = 1.0/(a00*a11 - a01*a10);
+      v[i][0] = detinv*( a11*b0 - a01*b1);
+      v[i][1] = detinv*(-a10*b0 + a00*b1);
+
+      dtirotate = dtfrotate / (radius[i]*radius[i]*rmass[i]);
+      omega[i][0] += dtirotate * torque[i][0];
+      omega[i][1] += dtirotate * torque[i][1];
+      omega[i][2] += dtirotate * torque[i][2];
+      rke += (omega[i][0]*omega[i][0] + omega[i][1]*omega[i][1] +
+              omega[i][2]*omega[i][2])*radius[i]*radius[i]*rmass[i];
+    }
+
+}

--- a/src/USER-DEMSI/fix_nve_sphere_demsi.h
+++ b/src/USER-DEMSI/fix_nve_sphere_demsi.h
@@ -17,8 +17,8 @@ FixStyle(nve/sphere/demsi,FixNVESphereDemsi)
 
 #else
 
-#ifndef LMP_FIX_NVE_SPHERE_H
-#define LMP_FIX_NVE_SPHERE_H
+#ifndef LMP_FIX_NVE_SPHERE_DEMSI_H
+#define LMP_FIX_NVE_SPHERE_DEMSI_H
 
 #include "fix_nve.h"
 

--- a/src/USER-DEMSI/fix_nve_sphere_demsi.h
+++ b/src/USER-DEMSI/fix_nve_sphere_demsi.h
@@ -36,6 +36,7 @@ class FixNVESphereDemsi : public FixNVE {
 
  protected:
   double inertia;
+  double **forcing;
   int ice_area_index, coriolis_index;
   int bx_index, by_index;
   int ocean_vel_x_index, ocean_vel_y_index;

--- a/src/USER-DEMSI/fix_nve_sphere_demsi.h
+++ b/src/USER-DEMSI/fix_nve_sphere_demsi.h
@@ -38,7 +38,7 @@ class FixNVESphereDemsi : public FixNVE {
   double inertia;
   int ice_area_index, coriolis_index;
   int bx_index, by_index;
-  int wind_vel_x_index, wind_vel_y_index;
+  int ocean_vel_x_index, ocean_vel_y_index;
 
 };
 

--- a/src/USER-DEMSI/fix_nve_sphere_demsi.h
+++ b/src/USER-DEMSI/fix_nve_sphere_demsi.h
@@ -32,14 +32,13 @@ class FixNVESphereDemsi : public FixNVE {
   virtual void initial_integrate(int);
   virtual void final_integrate();
 
+  //DEMSI sets these (presumably they never change during a run;
+  // if they are location/temperature dependent, they would have
+  // to be made into per-particle properties)
   double ocean_drag, ocean_density;
 
  protected:
   double inertia;
-  double **forcing;
-  int ice_area_index, coriolis_index;
-  int bx_index, by_index;
-  int ocean_vel_x_index, ocean_vel_y_index;
 
 };
 

--- a/src/USER-DEMSI/fix_nve_sphere_demsi.h
+++ b/src/USER-DEMSI/fix_nve_sphere_demsi.h
@@ -1,0 +1,78 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+
+FixStyle(nve/sphere/demsi,FixNVESphereDemsi)
+
+#else
+
+#ifndef LMP_FIX_NVE_SPHERE_H
+#define LMP_FIX_NVE_SPHERE_H
+
+#include "fix_nve.h"
+
+namespace LAMMPS_NS {
+
+class FixNVESphereDemsi : public FixNVE {
+ public:
+  FixNVESphereDemsi(class LAMMPS *, int, char **);
+  virtual ~FixNVESphereDemsi() {}
+  void init();
+  virtual void initial_integrate(int);
+  virtual void final_integrate();
+
+  double ocean_drag, ocean_density;
+
+ protected:
+  double inertia;
+  int ice_area_index, coriolis_index;
+  int bx_index, by_index;
+  int wind_vel_x_index, wind_vel_y_index;
+
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: Fix nve/sphere disc requires 2d simulation
+
+UNDOCUMENTED
+
+E: Fix nve/sphere requires atom style sphere
+
+Self-explanatory.
+
+E: Fix nve/sphere update dipole requires atom attribute mu
+
+An atom style with this attribute is needed.
+
+E: Fix nve/sphere requires extended particles
+
+This fix can only be used for particles of a finite size.
+
+U: Fix nve/sphere dlm must be used with update dipole
+
+The DLM algorithm can only be used in conjunction with update dipole.
+
+*/

--- a/src/USER-DEMSI/pair_gran_hooke_thickness.cpp
+++ b/src/USER-DEMSI/pair_gran_hooke_thickness.cpp
@@ -1,0 +1,349 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing authors: Leo Silbert (SNL), Gary Grest (SNL)
+------------------------------------------------------------------------- */
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include "pair_gran_hooke_thickness.h"
+#include "atom.h"
+#include "force.h"
+#include "fix.h"
+#include "neighbor.h"
+#include "neigh_list.h"
+#include "comm.h"
+#include "memory.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+PairGranHookeThickness::PairGranHookeThickness(LAMMPS *lmp) : PairGranHookeHistory(lmp)
+{
+  no_virial_fdotr_compute = 0;
+  history = 0;
+  if (!atom->demsi_flag){
+    error->all(FLERR,"Pair gran/hooke/thickness requires atom_style demsi");
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairGranHookeThickness::compute(int eflag, int vflag)
+{
+  int i,j,ii,jj,inum,jnum;
+  double xtmp,ytmp,ztmp,delx,dely,delz,fx,fy,fz;
+  double radi,radj,radsum,rsq,r,rinv,rsqinv;
+  double vr1,vr2,vr3,vnnr,vn1,vn2,vn3,vt1,vt2,vt3;
+  double wr1,wr2,wr3;
+  double vtr1,vtr2,vtr3,vrel;
+  double mi,mj,meff,damp,ccel,tor1,tor2,tor3;
+  double fn,fs,ft,fs1,fs2,fs3;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+  double min_thickness;
+
+  if (eflag || vflag) ev_setup(eflag,vflag);
+  else evflag = vflag_fdotr = 0;
+
+  // update rigid body info for owned & ghost atoms if using FixRigid masses
+  // body[i] = which body atom I is in, -1 if none
+  // mass_body = mass of each rigid body
+
+  if (fix_rigid && neighbor->ago == 0) {
+    int tmp;
+    int *body = (int *) fix_rigid->extract("body",tmp);
+    double *mass_body = (double *) fix_rigid->extract("masstotal",tmp);
+    if (atom->nmax > nmax) {
+      memory->destroy(mass_rigid);
+      nmax = atom->nmax;
+      memory->create(mass_rigid,nmax,"pair:mass_rigid");
+    }
+    int nlocal = atom->nlocal;
+    for (i = 0; i < nlocal; i++)
+      if (body[i] >= 0) mass_rigid[i] = mass_body[body[i]];
+      else mass_rigid[i] = 0.0;
+    comm->forward_comm_pair(this);
+  }
+
+  double **x = atom->x;
+  double **v = atom->v;
+  double **f = atom->f;
+  double **omega = atom->omega;
+  double **torque = atom->torque;
+  double *radius = atom->radius;
+  double *rmass = atom->rmass;
+  int *mask = atom->mask;
+  int nlocal = atom->nlocal;
+  int newton_pair = force->newton_pair;
+
+  inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = 0; ii < inum; ii++) {
+    i = ilist[ii];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    radi = radius[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      radj = radius[j];
+      radsum = radi + radj;
+
+      if (rsq < radsum*radsum) {
+        r = sqrt(rsq);
+        rinv = 1.0/r;
+        rsqinv = 1.0/rsq;
+
+        // relative translational velocity
+
+        vr1 = v[i][0] - v[j][0];
+        vr2 = v[i][1] - v[j][1];
+        vr3 = v[i][2] - v[j][2];
+
+        // normal component
+
+        vnnr = vr1*delx + vr2*dely + vr3*delz;
+        vn1 = delx*vnnr * rsqinv;
+        vn2 = dely*vnnr * rsqinv;
+        vn3 = delz*vnnr * rsqinv;
+
+        // tangential component
+
+        vt1 = vr1 - vn1;
+        vt2 = vr2 - vn2;
+        vt3 = vr3 - vn3;
+
+        // relative rotational velocity
+
+        wr1 = (radi*omega[i][0] + radj*omega[j][0]) * rinv;
+        wr2 = (radi*omega[i][1] + radj*omega[j][1]) * rinv;
+        wr3 = (radi*omega[i][2] + radj*omega[j][2]) * rinv;
+
+        // meff = effective mass of pair of particles
+        // if I or J part of rigid body, use body mass
+        // if I or J is frozen, meff is other particle
+
+        mi = rmass[i];
+        mj = rmass[j];
+        if (fix_rigid) {
+          if (mass_rigid[i] > 0.0) mi = mass_rigid[i];
+          if (mass_rigid[j] > 0.0) mj = mass_rigid[j];
+        }
+
+        min_thickness = MIN(atom->mean_thickness[i], atom->mean_thickness[j]);
+
+        meff = mi*mj / (mi+mj);
+        if (mask[i] & freeze_group_bit) meff = mj;
+        if (mask[j] & freeze_group_bit) meff = mi;
+
+        // normal forces = Hookian contact + normal velocity damping
+
+        damp = meff*gamman*vnnr*rsqinv;
+        ccel = min_thickness*kn*(radsum-r)*rinv - damp;
+
+        // relative velocities
+
+        vtr1 = vt1 - (delz*wr2-dely*wr3);
+        vtr2 = vt2 - (delx*wr3-delz*wr1);
+        vtr3 = vt3 - (dely*wr1-delx*wr2);
+        vrel = vtr1*vtr1 + vtr2*vtr2 + vtr3*vtr3;
+        vrel = sqrt(vrel);
+
+        // force normalization
+
+        fn = xmu * fabs(ccel*r);
+        fs = meff*min_thickness*gammat*vrel;
+        if (vrel != 0.0) ft = MIN(fn,fs) / vrel;
+        else ft = 0.0;
+
+        // tangential force due to tangential velocity damping
+
+        fs1 = -ft*vtr1;
+        fs2 = -ft*vtr2;
+        fs3 = -ft*vtr3;
+
+        // forces & torques
+
+        fx = delx*ccel + fs1;
+        fy = dely*ccel + fs2;
+        fz = delz*ccel + fs3;
+        f[i][0] += fx;
+        f[i][1] += fy;
+        f[i][2] += fz;
+
+        tor1 = rinv * (dely*fs3 - delz*fs2);
+        tor2 = rinv * (delz*fs1 - delx*fs3);
+        tor3 = rinv * (delx*fs2 - dely*fs1);
+        torque[i][0] -= radi*tor1;
+        torque[i][1] -= radi*tor2;
+        torque[i][2] -= radi*tor3;
+
+        if (newton_pair || j < nlocal) {
+          f[j][0] -= fx;
+          f[j][1] -= fy;
+          f[j][2] -= fz;
+          torque[j][0] -= radj*tor1;
+          torque[j][1] -= radj*tor2;
+          torque[j][2] -= radj*tor3;
+        }
+
+        if (evflag) ev_tally_xyz(i,j,nlocal,newton_pair,
+                                 0.0,0.0,fx,fy,fz,delx,dely,delz);
+      }
+    }
+  }
+
+  if (vflag_fdotr) virial_fdotr_compute();
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairGranHookeThickness::single(int i, int j, int /*itype*/, int /*jtype*/, double rsq,
+                             double /*factor_coul*/, double /*factor_lj*/,
+                             double &fforce)
+{
+  double radi,radj,radsum,r,rinv,rsqinv;
+  double delx,dely,delz;
+  double vr1,vr2,vr3,vnnr,vn1,vn2,vn3,vt1,vt2,vt3,wr1,wr2,wr3;
+  double vtr1,vtr2,vtr3,vrel;
+  double mi,mj,meff,damp,ccel;
+  double fn,fs,ft;
+
+  double *radius = atom->radius;
+  radi = radius[i];
+  radj = radius[j];
+  radsum = radi + radj;
+
+  // zero out forces if caller requests non-touching pair outside cutoff
+
+  if (rsq >= radsum*radsum) {
+    fforce = 0.0;
+    for (int m = 0; m < single_extra; m++) svector[m] = 0.0;
+    return 0.0;
+  }
+
+  r = sqrt(rsq);
+  rinv = 1.0/r;
+  rsqinv = 1.0/rsq;
+
+  // relative translational velocity
+
+  double **v = atom->v;
+  vr1 = v[i][0] - v[j][0];
+  vr2 = v[i][1] - v[j][1];
+  vr3 = v[i][2] - v[j][2];
+
+  // normal component
+
+  double **x = atom->x;
+  delx = x[i][0] - x[j][0];
+  dely = x[i][1] - x[j][1];
+  delz = x[i][2] - x[j][2];
+
+  vnnr = vr1*delx + vr2*dely + vr3*delz;
+  vn1 = delx*vnnr * rsqinv;
+  vn2 = dely*vnnr * rsqinv;
+  vn3 = delz*vnnr * rsqinv;
+
+  // tangential component
+
+  vt1 = vr1 - vn1;
+  vt2 = vr2 - vn2;
+  vt3 = vr3 - vn3;
+
+  // relative rotational velocity
+
+  double **omega = atom->omega;
+  wr1 = (radi*omega[i][0] + radj*omega[j][0]) * rinv;
+  wr2 = (radi*omega[i][1] + radj*omega[j][1]) * rinv;
+  wr3 = (radi*omega[i][2] + radj*omega[j][2]) * rinv;
+
+  // meff = effective mass of pair of particles
+  // if I or J part of rigid body, use body mass
+  // if I or J is frozen, meff is other particle
+
+  double *rmass = atom->rmass;
+  int *mask = atom->mask;
+
+  mi = rmass[i];
+  mj = rmass[j];
+  if (fix_rigid) {
+    // NOTE: insure mass_rigid is current for owned+ghost atoms?
+    if (mass_rigid[i] > 0.0) mi = mass_rigid[i];
+    if (mass_rigid[j] > 0.0) mj = mass_rigid[j];
+  }
+
+  meff = mi*mj / (mi+mj);
+  if (mask[i] & freeze_group_bit) meff = mj;
+  if (mask[j] & freeze_group_bit) meff = mi;
+
+  // normal forces = Hookian contact + normal velocity damping
+
+  damp = meff*gamman*vnnr*rsqinv;
+  ccel = kn*(radsum-r)*rinv - damp;
+
+  // relative velocities
+
+  vtr1 = vt1 - (delz*wr2-dely*wr3);
+  vtr2 = vt2 - (delx*wr3-delz*wr1);
+  vtr3 = vt3 - (dely*wr1-delx*wr2);
+  vrel = vtr1*vtr1 + vtr2*vtr2 + vtr3*vtr3;
+  vrel = sqrt(vrel);
+
+  // force normalization
+
+  fn = xmu * fabs(ccel*r);
+  fs = meff*gammat*vrel;
+  if (vrel != 0.0) ft = MIN(fn,fs) / vrel;
+  else ft = 0.0;
+
+  // set force and return no energy
+
+  fforce = ccel;
+
+
+  // set single_extra quantities
+
+  svector[0] = -ft*vtr1;
+  svector[1] = -ft*vtr2;
+  svector[2] = -ft*vtr3;
+  svector[3] = sqrt(svector[0]*svector[0] +
+                    svector[1]*svector[1] +
+                    svector[2]*svector[2]);
+  svector[4] = vn1;
+  svector[5] = vn2;
+  svector[6] = vn3;
+  svector[7] = vt1;
+  svector[8] = vt2;
+  svector[9] = vt3;
+
+  return 0.0;
+}

--- a/src/USER-DEMSI/pair_gran_hooke_thickness.h
+++ b/src/USER-DEMSI/pair_gran_hooke_thickness.h
@@ -1,0 +1,37 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+
+PairStyle(gran/hooke/thickness, PairGranHookeThickness)
+
+#else
+
+#ifndef LMP_PAIR_GRAN_HOOKE_THICKNESS_H
+#define LMP_PAIR_GRAN_HOOKE_THICKNESS_H
+
+#include "pair_gran_hooke_history.h"
+
+namespace LAMMPS_NS {
+
+class PairGranHookeThickness : public PairGranHookeHistory {
+ public:
+  PairGranHookeThickness(class LAMMPS *);
+  virtual void compute(int, int);
+  double single(int, int, int, int, double, double, double, double &);
+};
+
+}
+
+#endif
+#endif

--- a/src/USER-DEMSI/pair_gran_hopkins.cpp
+++ b/src/USER-DEMSI/pair_gran_hopkins.cpp
@@ -181,6 +181,7 @@ void PairGranHopkins::compute_nonbonded(double *history, int* touch, int i, int 
     for (int k = 0; k < size_history; k++){
       history[k] = 0;
     }
+    delx = dely = fx = fy = 0; //for virial calculation
     //history[0] = history[4] = 1234; //for debugging
   }
   else{
@@ -248,7 +249,8 @@ void PairGranHopkins::compute_nonbonded(double *history, int* touch, int i, int 
       fnmag = fnmag_elastic;
     else
       fnmag = fnmag_plastic;
-    //fnmag = fnmag_elastic;
+
+    fnmag = fnmag_elastic;
 
     fnx = fnmag*nx;
     fny = fnmag*ny;

--- a/src/USER-DEMSI/pair_gran_hopkins.cpp
+++ b/src/USER-DEMSI/pair_gran_hopkins.cpp
@@ -250,7 +250,7 @@ void PairGranHopkins::compute_nonbonded(double *history, int* touch, int i, int 
     else
       fnmag = fnmag_plastic;
 
-    fnmag = fnmag_elastic;
+    //fnmag = fnmag_elastic;
 
     fnx = fnmag*nx;
     fny = fnmag*ny;

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -111,9 +111,14 @@ Atom::Atom(LAMMPS *lmp) : Pointers(lmp)
   cc = cc_flux = NULL;
   edpd_temp = edpd_flux = edpd_cv = NULL;
 
-  // USER-DEMSI
+  //USER-DEMSI
   forcing = NULL;
-  mean_thickness = min_thickness = NULL;
+  mean_thickness = NULL;
+  min_thickness = NULL;
+  ice_area = NULL;
+  coriolis = NULL;
+  ocean_vel = NULL;
+  bvector = NULL;
 
   // USER-SMD
 

--- a/src/atom.h
+++ b/src/atom.h
@@ -106,9 +106,34 @@ class Atom : protected Pointers {
   double *edpd_cv;               // heat capacity
   int cc_species;
 
-  // USER-DEMSI package
+  //USER-DEMSI package
   double **forcing;
-  double *mean_thickness, *min_thickness;
+  double *mean_thickness;
+  double *min_thickness;
+  double *ice_area;
+  double *coriolis;
+  double **ocean_vel;
+  double **bvector;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   // molecular info
 
@@ -170,8 +195,28 @@ class Atom : protected Pointers {
   int eff_plastic_strain_rate_flag;
   int damage_flag;
 
-  // USER-DEMSI package
+  //USER-DEMSI package
   int demsi_flag;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   // Peridynamics scale factor, used by dump cfg
 


### PR DESCRIPTION
Several changes to enable semi-implicit Verlet integration scheme:
* Several new per-atom properties, hence changes to `atom_vec_demsi.cpp/h`
* Communication of per-atom properties more economical (i.e. no longer at every LAMMPS step, as these are not changing as frequently)
* New `fix nve/sphere/demsi` replaces old `fix nve/sphere` + `fix addforce`

Also includes `pair gran/hooke/thickness`, a contact model that is simply hooke with a thickness scaling of the stiffness.