### PR TITLE
Update atom_vec_demsi_kokkos with new additions for implicit time stepping

### DIFF
--- a/src/KOKKOS/atom_kokkos.cpp
+++ b/src/KOKKOS/atom_kokkos.cpp
@@ -79,6 +79,10 @@ AtomKokkos::~AtomKokkos()
   memoryKK->destroy_kokkos(k_mean_thickness,mean_thickness);
   memoryKK->destroy_kokkos(k_min_thickness,min_thickness);
   memoryKK->destroy_kokkos(k_forcing,forcing);
+  memoryKK->destroy_kokkos(k_ice_area,ice_area);
+  memoryKK->destroy_kokkos(k_coriolis,coriolis);
+  memoryKK->destroy_kokkos(k_ocean_vel,ocean_vel);
+  memoryKK->destroy_kokkos(k_bvector,bvector);
 
   // USER-DPD package
   memoryKK->destroy_kokkos(k_uCond,uCond);

--- a/src/KOKKOS/atom_kokkos.h
+++ b/src/KOKKOS/atom_kokkos.h
@@ -56,7 +56,9 @@ class AtomKokkos : public Atom {
 
 // USER-DEMSI package
   DAT::tdual_float_1d  k_min_thickness,k_mean_thickness;
+  DAT::tdual_float_1d  k_ice_area,k_coriolis;
   DAT::tdual_float_2d  k_forcing;
+  DAT::tdual_float_2d  k_ocean_vel,k_bvector;
                        
 
 // USER-DPD package

--- a/src/KOKKOS/atom_vec_demsi_kokkos.h
+++ b/src/KOKKOS/atom_vec_demsi_kokkos.h
@@ -120,6 +120,10 @@ class AtomVecDemsiKokkos : public AtomVecKokkos {
   double **omega,**torque;
   double **forcing;
   double *mean_thickness,*min_thickness;
+  double * ice_area;
+  double * coriolis;
+  double ** ocean_vel;
+  double ** bvector;
   int radvary;
 
   int **nspecial;
@@ -153,6 +157,14 @@ class AtomVecDemsiKokkos : public AtomVecKokkos {
   HAT::t_float_1d h_mean_thickness;
   DAT::t_float_1d d_min_thickness;
   HAT::t_float_1d h_min_thickness;
+  DAT::t_float_1d d_ice_area;
+  HAT::t_float_1d h_ice_area;
+  DAT::t_float_1d d_coriolis;
+  HAT::t_float_1d h_coriolis;
+  DAT::t_float_2d d_ocean_vel;
+  HAT::t_float_2d h_ocean_vel;
+  DAT::t_float_2d d_bvector;
+  HAT::t_float_2d h_bvector;
 
   DAT::t_int_2d d_nspecial;
   HAT::t_int_2d h_nspecial;


### PR DESCRIPTION

This pull request brings atom_vec_demsi_kokkos into sync with the updated atom_vec_demsi. 

