### PR TITLE
Bug fixes to kokkos versions of gran_hopkins and fix_neigh_history.

### DIFF
--- a/src/KOKKOS/fix_neigh_history_kokkos.cpp
+++ b/src/KOKKOS/fix_neigh_history_kokkos.cpp
@@ -236,6 +236,7 @@ void FixNeighHistoryKokkos<DeviceType>::post_neighbor_item(const int &ii) const
     int rflag = j >> SBBITS & 3;
     if (beyond_contact) rflag = 1;
     j &= NEIGHMASK;
+    d_neighbors(i,jj) = j; 
 
     int m;
     if (rflag) {
@@ -341,9 +342,9 @@ int FixNeighHistoryKokkos<DeviceType>::pack_exchange(int i, double *buf)
   k_valuepartner.template sync<LMPHostType>();
 
   int n = 0;
-  buf[n++] = npartner[i];
-  for (int m = 0; m < npartner[i]; m++) buf[n++] = partner[i][m];
-  for (int m = 0; m < dnum*npartner[i]; m++) buf[n++] = valuepartner[i][m];
+  buf[n++] = h_npartner(i);
+  for (int m = 0; m < h_npartner(i); m++) buf[n++] = h_partner(i,m);
+  for (int m = 0; m < dnum*h_npartner(i); m++) buf[n++] = h_valuepartner(i,m);
 
   return n;
 }
@@ -356,9 +357,9 @@ template<class DeviceType>
 int FixNeighHistoryKokkos<DeviceType>::unpack_exchange(int nlocal, double *buf)
 {
   int n = 0;
-  npartner[nlocal] = static_cast<int>(buf[n++]);
-  for (int m = 0; m < npartner[nlocal]; m++) partner[nlocal][m] = static_cast<int>(buf[n++]);
-  for (int m = 0; m < dnum*npartner[nlocal]; m++) valuepartner[nlocal][m] = buf[n++];
+  h_npartner(nlocal) = static_cast<int>(buf[n++]);
+  for (int m = 0; m < h_npartner(nlocal); m++) h_partner(nlocal,m) = static_cast<int>(buf[n++]);
+  for (int m = 0; m < dnum*h_npartner(nlocal); m++) h_valuepartner(nlocal,m) = buf[n++];
 
   k_npartner.template modify<LMPHostType>();
   k_partner.template modify<LMPHostType>();

--- a/src/KOKKOS/pair_gran_hopkins_kokkos.cpp
+++ b/src/KOKKOS/pair_gran_hopkins_kokkos.cpp
@@ -388,6 +388,8 @@ void PairGranHopkinsKokkos<DeviceType>::compute_nonbonded_kokkos(int i, int j, i
      for (int k = 0; k < size_history; k++) {
         d_firsthistory(i,size_history*jj+k) = 0;
      }
+     fx = fy = 0;
+     torque_i = torque_j = 0;
    }
    else{
      if (!d_firsttouch(i,jj)){ //If this is first contact
@@ -459,7 +461,6 @@ void PairGranHopkinsKokkos<DeviceType>::compute_nonbonded_kokkos(int i, int j, i
        fnmag = fnmag_elastic;
      else
        fnmag = fnmag_plastic;
-    // fnmag = fnmag_elastic;
 
      fnx = fnmag*nx;
      fny = fnmag*ny;
@@ -511,8 +512,12 @@ void PairGranHopkinsKokkos<DeviceType>::compute_nonbonded_kokkos(int i, int j, i
 
     //Torque
     ncrossF = nx*fty - ny*ftx;
-    torque_i = -radius[i]*ncrossF;
-    torque_j = -radius[j]*ncrossF;
+    torque_i = -radius(i)*ncrossF;
+
+    torque_j = 0;
+    if (NEWTON_PAIR || j < nlocal){
+      torque_j = -radius(j)*ncrossF;
+    }
 
   } // rsq < radsum*radsum
 }


### PR DESCRIPTION
These changes appear to remove processor boundary artifacts in the uniform stress test case.  

However, the Kokkos version of the code does not exactly reproduce results for the non-Kokkos version of the code in tests using the gran_hopkins pair style. These changes along with small changes in a DEMSI pull request do make the differences between Kokkos and non-Kokkos versions much smaller for the cantilever beam tests and the uniform stress test. 

