### PR TITLE
Convert new DEMSI contact models and fix to Kokkos, other bug fixes.

### DIFF
--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -121,6 +121,8 @@ action fix_nve_kokkos.cpp
 action fix_nve_kokkos.h
 action fix_nve_sphere_kokkos.cpp
 action fix_nve_sphere_kokkos.h
+action fix_nve_sphere_demsi_kokkos.cpp
+action fix_nve_sphere_demsi_kokkos.h
 action fix_nvt_kokkos.cpp
 action fix_nvt_kokkos.h
 action fix_property_atom_kokkos.cpp
@@ -211,6 +213,10 @@ action pair_exp6_rx_kokkos.cpp pair_exp6_rx.cpp
 action pair_exp6_rx_kokkos.h pair_exp6_rx.h
 action pair_gran_hooke_history_kokkos.h pair_gran_hooke_history.h
 action pair_gran_hooke_history_kokkos.cpp pair_gran_hooke_history.cpp
+action pair_gran_hooke_kokkos.h pair_gran_hooke.h
+action pair_gran_hooke_kokkos.cpp pair_gran_hooke.cpp
+action pair_gran_hooke_thickness_kokkos.h pair_gran_hooke_thickness.h
+action pair_gran_hooke_thickness_kokkos.cpp pair_gran_hooke_thickness.cpp
 action pair_gran_hopkins_kokkos.h pair_gran_hopkins.h
 action pair_gran_hopkins_kokkos.cpp pair_gran_hopkins.cpp
 action pair_hybrid_kokkos.cpp

--- a/src/KOKKOS/atom_vec_demsi_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_demsi_kokkos.cpp
@@ -3367,9 +3367,9 @@ void AtomVecDemsiKokkos::data_vel(int m, char **values)
 int AtomVecDemsiKokkos::data_vel_hybrid(int m, char **values)
 {
   sync(Host,OMEGA_MASK);
-  omega[m][0] = atof(values[0]);
-  omega[m][1] = atof(values[1]);
-  omega[m][2] = atof(values[2]);
+  h_omega(m,0) = atof(values[0]);
+  h_omega(m,1) = atof(values[1]);
+  h_omega(m,2) = atof(values[2]);
   modified(Host,OMEGA_MASK);
   return 3;
 }

--- a/src/KOKKOS/fix_neigh_history_kokkos.cpp
+++ b/src/KOKKOS/fix_neigh_history_kokkos.cpp
@@ -77,6 +77,10 @@ template <class DeviceType>
 void FixNeighHistoryKokkos<DeviceType>::pre_exchange()
 {
   copymode = 1;
+
+  k_partner.template sync<LMPDeviceType>();
+  k_npartner.template sync<LMPDeviceType>();
+  k_valuepartner.template sync<LMPDeviceType>();
   
   h_resize() = 1;
   while (h_resize() > 0) {
@@ -98,6 +102,14 @@ void FixNeighHistoryKokkos<DeviceType>::pre_exchange()
       memoryKK->grow_kokkos(k_valuepartner,valuepartner,atom->nmax,dnum*maxpartner,"neighbor_history:valuepartner");
     }
   }
+
+  k_partner.template modify<LMPDeviceType>();
+  k_npartner.template modify<LMPDeviceType>();
+  k_valuepartner.template modify<LMPDeviceType>();
+
+  k_partner.template sync<LMPHostType>();
+  k_npartner.template sync<LMPHostType>();
+  k_valuepartner.template sync<LMPHostType>();
 
   copymode = 0;
 
@@ -188,6 +200,10 @@ void FixNeighHistoryKokkos<DeviceType>::setup_post_neighbor()
 template <class DeviceType>
 void FixNeighHistoryKokkos<DeviceType>::post_neighbor()
 {
+  k_partner.template sync<LMPDeviceType>();
+  k_npartner.template sync<LMPDeviceType>();
+  k_valuepartner.template sync<LMPDeviceType>();
+
   tag = atomKK->k_tag.view<DeviceType>();
   
   int inum = pair->list->inum;

--- a/src/KOKKOS/fix_nve_sphere_demsi_kokkos.cpp
+++ b/src/KOKKOS/fix_nve_sphere_demsi_kokkos.cpp
@@ -1,0 +1,191 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "fix_nve_sphere_demsi_kokkos.h"
+#include "atom_masks.h"
+#include "atom_kokkos.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+enum{NONE,DIPOLE};
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+FixNVESphereDemsiKokkos<DeviceType>::FixNVESphereDemsiKokkos(LAMMPS *lmp, int narg, char **arg) :
+  FixNVESphereDemsi(lmp, narg, arg)
+{
+  kokkosable = 1;
+  atomKK = (AtomKokkos *)atom;
+  execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
+
+  datamask_read = F_MASK | TORQUE_MASK | RMASS_MASK | RADIUS_MASK | MASK_MASK | THICKNESS_MASK;
+  datamask_modify = X_MASK | V_MASK | OMEGA_MASK;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void FixNVESphereDemsiKokkos<DeviceType>::cleanup_copy()
+{
+  id = style = NULL;
+  vatom = NULL;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void FixNVESphereDemsiKokkos<DeviceType>::init()
+{
+  FixNVESphereDemsi::init();
+
+//  if (extra == DIPOLE) {
+//    error->all(FLERR,"Fix nve/sphere/demsi/kk doesn't yet support dipole");
+//  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void FixNVESphereDemsiKokkos<DeviceType>::initial_integrate(int vflag)
+{
+  atomKK->sync(execution_space,datamask_read);
+  atomKK->modified(execution_space,datamask_modify);
+
+  x = atomKK->k_x.view<DeviceType>();
+  v = atomKK->k_v.view<DeviceType>();
+  omega = atomKK->k_omega.view<DeviceType>();
+  f = atomKK->k_f.view<DeviceType>();
+  torque = atomKK->k_torque.view<DeviceType>();
+  mask = atomKK->k_mask.view<DeviceType>();
+  rmass = atomKK->k_rmass.view<DeviceType>();
+  radius = atomKK->k_radius.view<DeviceType>();
+  ice_area = atomKK->k_ice_area.view<DeviceType>();
+  coriolis = atomKK->k_coriolis.view<DeviceType>();
+  ocean_vel = atomKK->k_ocean_vel.view<DeviceType>();
+  bvector = atomKK->k_bvector.view<DeviceType>();
+  forcing = atomKK->k_forcing.view<DeviceType>();
+
+  int nlocal = atom->nlocal;
+  if (igroup == atom->firstgroup) nlocal = atom->nfirst;
+
+  FixNVESphereDemsiKokkosInitialIntegrateFunctor<DeviceType> f(this); 
+  Kokkos::parallel_for(nlocal,f);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void FixNVESphereDemsiKokkos<DeviceType>::initial_integrate_item(const int i) const
+{
+  const double dtfrotate = dtf / inertia;
+
+  if (mask(i) & groupbit) {
+    const double vel_diff = sqrt((ocean_vel(i,0)-v(i,0))*(ocean_vel(i,0)-v(i,0)) +
+         (ocean_vel(i,1)-v(i,1))*(ocean_vel(i,1)-v(i,1)));
+    const double D = ice_area(i)*ocean_drag*ocean_density*vel_diff;
+    const double m_prime = rmass(i)/dtf;
+    const double a00 = m_prime+D;
+    const double a11 = a00;
+    const double a10 = rmass(i)*coriolis(i);
+    const double a01 = -a10;
+
+    const double b0 = m_prime*v(i,0) + f(i,0) + bvector(i,0) + forcing(i,0) + D*ocean_vel(i,0);
+    const double b1 = m_prime*v(i,1) + f(i,1) + bvector(i,1) + forcing(i,1) + D*ocean_vel(i,1);
+
+    const double detinv = 1.0/(a00*a11 - a01*a10);
+    v(i,0) = detinv*( a11*b0 - a01*b1);
+    v(i,1) = detinv*(-a10*b0 + a00*b1);
+
+    x(i,0) += dtv * v(i,0);
+    x(i,1) += dtv * v(i,1);
+
+    const double dtirotate = dtfrotate / (radius(i)*radius(i)*rmass(i));
+    omega(i,2) += dtirotate * torque(i,2);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void FixNVESphereDemsiKokkos<DeviceType>::final_integrate()
+{
+  atomKK->sync(execution_space,datamask_read);
+  atomKK->modified(execution_space,datamask_modify);
+
+  v = atomKK->k_v.view<DeviceType>();
+  omega = atomKK->k_omega.view<DeviceType>();
+  f = atomKK->k_f.view<DeviceType>();
+  torque = atomKK->k_torque.view<DeviceType>();
+  mask = atomKK->k_mask.view<DeviceType>();
+  rmass = atomKK->k_rmass.view<DeviceType>();
+  radius = atomKK->k_radius.view<DeviceType>();
+  ice_area = atomKK->k_ice_area.view<DeviceType>();
+  coriolis = atomKK->k_coriolis.view<DeviceType>();
+  ocean_vel = atomKK->k_ocean_vel.view<DeviceType>();
+  bvector = atomKK->k_bvector.view<DeviceType>();
+  forcing = atomKK->k_forcing.view<DeviceType>();
+
+  int nlocal = atom->nlocal;
+  if (igroup == atom->firstgroup) nlocal = atom->nfirst;
+
+  FixNVESphereDemsiKokkosFinalIntegrateFunctor<DeviceType> f(this);
+  Kokkos::parallel_for(nlocal,f);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void FixNVESphereDemsiKokkos<DeviceType>::final_integrate_item(const int i) const
+{
+  const double dtfrotate = dtf / inertia;
+
+  if (mask(i) & groupbit) {
+
+    const double vel_diff = sqrt((ocean_vel(i,0)-v(i,0))*(ocean_vel(i,0)-v(i,0)) +
+         (ocean_vel(i,1)-v(i,1))*(ocean_vel(i,1)-v(i,1)));
+    const double D = ice_area(i)*ocean_drag*ocean_density*vel_diff;
+    const double m_prime = rmass(i)/dtf;
+    const double a00 = m_prime+D;
+    const double a11 = a00;
+    const double a10 = rmass(i)*coriolis(i);
+    const double a01 = -a10;
+
+    const double b0 = m_prime*v(i,0) + f(i,0) + bvector(i,0) + forcing(i,0) + D*ocean_vel(i,0);
+    const double b1 = m_prime*v(i,1) + f(i,1) + bvector(i,1) + forcing(i,1) + D*ocean_vel(i,1);
+
+    const double detinv = 1.0/(a00*a11 - a01*a10);
+    v(i,0) = detinv*( a11*b0 - a01*b1);
+    v(i,1) = detinv*(-a10*b0 + a00*b1);
+
+    x(i,0) += dtv * v(i,0);
+    x(i,1) += dtv * v(i,1);
+
+    const double dtirotate = dtfrotate / (radius(i)*radius(i)*rmass(i));
+    omega(i,2) += dtirotate * torque(i,2);
+
+  //  rke += (omega(i,0)*omega(i,0) + omega(i,1)*omega(i,1) +
+  //         omega(i,2)*omega(i,2))*radius(i)*radius(i)*rmass(i);
+ 
+  }
+}
+
+namespace LAMMPS_NS {
+template class FixNVESphereDemsiKokkos<LMPDeviceType>;
+#ifdef KOKKOS_HAVE_CUDA
+template class FixNVESphereDemsiKokkos<LMPHostType>;
+#endif
+}

--- a/src/KOKKOS/fix_nve_sphere_demsi_kokkos.h
+++ b/src/KOKKOS/fix_nve_sphere_demsi_kokkos.h
@@ -1,0 +1,84 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+
+FixStyle(nve/sphere/demsi/kk,FixNVESphereDemsiKokkos<LMPDeviceType>)
+FixStyle(nve/sphere/demsi/kk/device,FixNVESphereDemsiKokkos<LMPDeviceType>)
+FixStyle(nve/sphere/demsi/kk/host,FixNVESphereDemsiKokkos<LMPHostType>)
+
+#else
+
+#ifndef LMP_FIX_NVE_SPHERE_DEMSI_KOKKOS_H
+#define LMP_FIX_NVE_SPHERE_DEMSI_KOKKOS_H
+
+#include "fix_nve_sphere_demsi.h"
+#include "kokkos_type.h"
+
+namespace LAMMPS_NS {
+  
+template<class DeviceType>
+class FixNVESphereDemsiKokkos : public FixNVESphereDemsi {
+  public:
+    FixNVESphereDemsiKokkos(class LAMMPS *, int, char **);
+    virtual ~FixNVESphereDemsiKokkos() {}
+    void cleanup_copy();
+    void init();
+    void initial_integrate(int);
+    void final_integrate();
+  
+    KOKKOS_INLINE_FUNCTION
+    void initial_integrate_item(const int i) const;
+    KOKKOS_INLINE_FUNCTION
+    void final_integrate_item(const int i) const;
+
+  private:
+    typename ArrayTypes<DeviceType>::t_x_array x;
+    typename ArrayTypes<DeviceType>::t_v_array v;
+    typename ArrayTypes<DeviceType>::t_v_array omega;
+    typename ArrayTypes<DeviceType>::t_f_array f;
+    typename ArrayTypes<DeviceType>::t_f_array torque;
+    typename ArrayTypes<DeviceType>::t_float_1d rmass;
+    typename ArrayTypes<DeviceType>::t_float_1d radius;
+    typename ArrayTypes<DeviceType>::t_int_1d mask;
+    typename ArrayTypes<DeviceType>::t_float_2d forcing;
+    typename ArrayTypes<DeviceType>::t_float_1d ice_area;
+    typename ArrayTypes<DeviceType>::t_float_1d coriolis;
+    typename ArrayTypes<DeviceType>::t_float_2d ocean_vel;
+    typename ArrayTypes<DeviceType>::t_float_2d bvector;
+};
+
+template <class DeviceType>
+struct FixNVESphereDemsiKokkosInitialIntegrateFunctor {
+  FixNVESphereDemsiKokkos<DeviceType> c;
+  FixNVESphereDemsiKokkosInitialIntegrateFunctor(FixNVESphereDemsiKokkos<DeviceType> *c_ptr): c(*c_ptr) { c.cleanup_copy(); }
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int i) const {
+    c.initial_integrate_item(i);
+  }
+};
+
+template <class DeviceType>
+struct FixNVESphereDemsiKokkosFinalIntegrateFunctor {
+  FixNVESphereDemsiKokkos<DeviceType> c;
+  FixNVESphereDemsiKokkosFinalIntegrateFunctor(FixNVESphereDemsiKokkos<DeviceType> *c_ptr): c(*c_ptr) { c.cleanup_copy(); }
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int i) const {
+    c.final_integrate_item(i);
+  }
+};
+
+} // namespace LAMMPS_NS
+
+#endif // LMP_FIX_NVE_SPHERE_DEMSI_KOKKOS_H
+#endif // FIX_CLASS

--- a/src/KOKKOS/pair_gran_hooke_kokkos.cpp
+++ b/src/KOKKOS/pair_gran_hooke_kokkos.cpp
@@ -1,0 +1,438 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_gran_hooke_kokkos.h"
+#include "kokkos.h"
+#include "atom_kokkos.h"
+#include "atom_masks.h"
+#include "memory_kokkos.h"
+#include "force.h"
+#include "neighbor.h"
+#include "neigh_list.h"
+#include "neigh_request.h"
+#include "error.h"
+#include "modify.h"
+#include "fix_neigh_history_kokkos.h"
+#include "update.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+PairGranHookeKokkos<DeviceType>::PairGranHookeKokkos(LAMMPS *lmp) : PairGranHooke(lmp)
+{
+  atomKK = (AtomKokkos *) atom;
+  execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
+  datamask_read = X_MASK | V_MASK | OMEGA_MASK | F_MASK | TORQUE_MASK | TYPE_MASK | MASK_MASK | ENERGY_MASK | VIRIAL_MASK | RMASS_MASK | RADIUS_MASK;
+  datamask_modify = F_MASK | TORQUE_MASK | ENERGY_MASK | VIRIAL_MASK;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+PairGranHookeKokkos<DeviceType>::~PairGranHookeKokkos()
+{
+  if (copymode) return;
+
+  if (allocated) {
+    memoryKK->destroy_kokkos(k_eatom,eatom);
+    memoryKK->destroy_kokkos(k_vatom,vatom);
+    eatom = NULL;
+    vatom = NULL;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   init specific to this pair style
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+void PairGranHookeKokkos<DeviceType>::init_style()
+{
+  if (history && fix_history == NULL) {
+    char dnumstr[16];
+    sprintf(dnumstr,"%d",3);
+    char **fixarg = new char*[4];
+    fixarg[0] = (char *) "NEIGH_HISTORY";
+    fixarg[1] = (char *) "all";
+    if (execution_space == Device)
+      fixarg[2] = (char *) "NEIGH_HISTORY/KK/DEVICE";
+    else
+      fixarg[2] = (char *) "NEIGH_HISTORY/KK/HOST";
+    fixarg[3] = dnumstr;
+    modify->add_fix(4,fixarg,1);
+    delete [] fixarg;
+    fix_history = (FixNeighHistory *) modify->fix[modify->nfix-1];
+    fix_history->pair = this;
+    fix_historyKK = (FixNeighHistoryKokkos<DeviceType> *)fix_history;
+  }
+
+  PairGranHookeHistory::init_style();
+
+  // irequest = neigh request made by parent class
+
+  neighflag = lmp->kokkos->neighflag;
+  int irequest = neighbor->nrequest - 1;
+
+  neighbor->requests[irequest]->
+    kokkos_host = Kokkos::Impl::is_same<DeviceType,LMPHostType>::value &&
+    !Kokkos::Impl::is_same<DeviceType,LMPDeviceType>::value;
+  neighbor->requests[irequest]->
+    kokkos_device = Kokkos::Impl::is_same<DeviceType,LMPDeviceType>::value;
+
+  if (neighflag == HALF || neighflag == HALFTHREAD) {
+    neighbor->requests[irequest]->full = 0;
+    neighbor->requests[irequest]->half = 1;
+  } else {
+    error->all(FLERR,"Cannot use chosen neighbor list style with gran/hooke/kk");
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void PairGranHookeKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
+{
+  copymode = 1;
+
+  eflag = eflag_in;
+  vflag = vflag_in;
+
+  if (neighflag == FULL) no_virial_fdotr_compute = 1;
+
+  if (eflag || vflag) ev_setup(eflag,vflag,0);
+  else evflag = vflag_fdotr = 0;
+
+  // reallocate per-atom arrays if necessary
+
+  if (eflag_atom) {
+    memoryKK->destroy_kokkos(k_eatom,eatom);
+    memoryKK->create_kokkos(k_eatom,eatom,maxeatom,"pair:eatom");
+    d_eatom = k_eatom.view<DeviceType>();
+  }
+  if (vflag_atom) {
+    memoryKK->destroy_kokkos(k_vatom,vatom);
+    memoryKK->create_kokkos(k_vatom,vatom,maxvatom,6,"pair:vatom");
+    d_vatom = k_vatom.view<DeviceType>();
+  }
+
+  atomKK->sync(execution_space,datamask_read);
+  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
+  else atomKK->modified(execution_space,F_MASK | TORQUE_MASK);
+
+  x = atomKK->k_x.view<DeviceType>();
+  v = atomKK->k_v.view<DeviceType>();
+  omega = atomKK->k_omega.view<DeviceType>();
+  f = atomKK->k_f.view<DeviceType>();
+  torque = atomKK->k_torque.view<DeviceType>();
+  type = atomKK->k_type.view<DeviceType>();
+  mask = atomKK->k_mask.view<DeviceType>();
+  tag = atomKK->k_tag.view<DeviceType>();
+  rmass = atomKK->k_rmass.view<DeviceType>();
+  radius = atomKK->k_radius.view<DeviceType>();
+  nlocal = atom->nlocal;
+  nall = atom->nlocal + atom->nghost;
+  newton_pair = force->newton_pair;
+
+  int inum = list->inum;
+  NeighListKokkos<DeviceType>* k_list = static_cast<NeighListKokkos<DeviceType>*>(list);
+  d_numneigh = k_list->d_numneigh;
+  d_neighbors = k_list->d_neighbors;
+  d_ilist = k_list->d_ilist;
+
+  EV_FLOAT ev;
+
+  if (lmp->kokkos->neighflag == HALF) {
+    if (force->newton_pair) {
+      if (vflag_atom) {
+         Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeCompute<HALF,1,2>>(0,inum),*this);
+      } else if (vflag_global) {
+         Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairGranHookeCompute<HALF,1,1>>(0,inum),*this, ev);
+      } else {
+         Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeCompute<HALF,1,0>>(0,inum),*this);
+      }
+    } else {
+      if (vflag_atom) {
+	Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeCompute<HALF,0,2>>(0,inum),*this);
+      } else if (vflag_global) {
+	Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairGranHookeCompute<HALF,0,1>>(0,inum),*this, ev);
+      } else {
+        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeCompute<HALF,0,0>>(0,inum),*this);
+      }
+    }
+  } else { // HALFTHREAD
+    if (force->newton_pair) {
+      if (vflag_atom) {
+        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeCompute<HALFTHREAD,1,2>>(0,inum),*this);
+      } else if (vflag_global) {
+	Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairGranHookeCompute<HALFTHREAD,1,1>>(0,inum),*this, ev);
+      } else {
+        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeCompute<HALFTHREAD,1,0>>(0,inum),*this);
+      }
+    } else {
+      if (vflag_atom) {
+	Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeCompute<HALFTHREAD,0,2>>(0,inum),*this);
+      } else if (vflag_global) {
+	Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairGranHookeCompute<HALFTHREAD,0,1>>(0,inum),*this, ev);
+      } else {
+	Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeCompute<HALFTHREAD,0,0>>(0,inum),*this);
+      }
+    }
+  }
+
+  if (vflag_global) {
+    virial[0] += ev.v[0];
+    virial[1] += ev.v[1];
+    virial[2] += ev.v[2];
+    virial[3] += ev.v[3];
+    virial[4] += ev.v[4];
+    virial[5] += ev.v[5];
+  }
+
+  if (vflag_atom) {
+    k_vatom.template modify<DeviceType>();
+    k_vatom.template sync<LMPHostType>();
+  }
+
+  if (vflag_fdotr) pair_virial_fdotr_compute(this);
+
+  copymode = 0;
+}
+
+template<class DeviceType>
+template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void PairGranHookeKokkos<DeviceType>::operator()(TagPairGranHookeCompute<NEIGHFLAG,NEWTON_PAIR,EVFLAG>, const int ii, EV_FLOAT &ev) const {
+
+  // The f and torque arrays are atomic for Half/Thread neighbor style
+  Kokkos::View<F_FLOAT*[3], typename DAT::t_f_array::array_layout,DeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > a_f = f;
+  Kokkos::View<F_FLOAT*[3], typename DAT::t_f_array::array_layout,DeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > a_torque = torque;
+
+  const int i = d_ilist[ii];
+  const X_FLOAT xtmp = x(i,0);
+  const X_FLOAT ytmp = x(i,1);
+  const X_FLOAT ztmp = x(i,2);
+  const LMP_FLOAT irad = radius[i];
+  const LMP_FLOAT imass = rmass(i);
+  const int jnum = d_numneigh[i];
+  
+  F_FLOAT fx_i = 0.0;
+  F_FLOAT fy_i = 0.0;
+  F_FLOAT fz_i = 0.0;
+
+  F_FLOAT torquex_i = 0.0;
+  F_FLOAT torquey_i = 0.0;
+  F_FLOAT torquez_i = 0.0;
+
+  for (int jj = 0; jj < jnum; jj++) {
+    const int j = d_neighbors(i,jj) & NEIGHMASK;
+    
+    const X_FLOAT delx = xtmp - x(j,0);
+    const X_FLOAT dely = ytmp - x(j,1);
+    const X_FLOAT delz = ztmp - x(j,2);
+    const X_FLOAT rsq = delx*delx + dely*dely + delz*delz;
+    const LMP_FLOAT jrad = radius[j];
+    const LMP_FLOAT jmass = rmass(j);
+    const LMP_FLOAT radsum = irad + jrad;
+
+    // check for touching neighbors
+    if (rsq < radsum*radsum) {
+
+      const LMP_FLOAT r = sqrt(rsq);
+      const LMP_FLOAT rinv = 1.0/r;
+      const LMP_FLOAT rsqinv = 1/rsq;
+
+      // relative translational velocity
+      V_FLOAT vr1 = v(i,0) - v(j,0);
+      V_FLOAT vr2 = v(i,1) - v(j,1);
+      V_FLOAT vr3 = v(i,2) - v(j,2);
+      
+      // normal component
+      V_FLOAT vnnr = vr1*delx + vr2*dely + vr3*delz;
+      V_FLOAT vn1 = delx*vnnr * rsqinv;
+      V_FLOAT vn2 = dely*vnnr * rsqinv;
+      V_FLOAT vn3 = delz*vnnr * rsqinv;
+      
+      // tangential component
+      V_FLOAT vt1 = vr1 - vn1;
+      V_FLOAT vt2 = vr2 - vn2;
+      V_FLOAT vt3 = vr3 - vn3;
+
+      // relative rotational velocity
+      V_FLOAT wr1 = (irad*omega(i,0) + jrad*omega(j,0)) * rinv;
+      V_FLOAT wr2 = (irad*omega(i,1) + jrad*omega(j,1)) * rinv;
+      V_FLOAT wr3 = (irad*omega(i,2) + jrad*omega(j,2)) * rinv;
+
+      // meff = effective mass of pair of particles
+      // if I or J part of rigid body, use body mass
+      // if I or J is frozen, meff is other particle
+      LMP_FLOAT meff = imass*jmass / (imass+jmass);
+      if (mask[i] & freeze_group_bit) meff = jmass;
+      if (mask[j] & freeze_group_bit) meff = imass;
+
+      // normal forces = Hookian contact + normal velocity damping
+      F_FLOAT damp = meff*gamman*vnnr*rsqinv;
+      F_FLOAT ccel = kn*(radsum-r)*rinv - damp;
+
+      // relative velocities
+      V_FLOAT vtr1 = vt1 - (delz*wr2-dely*wr3);
+      V_FLOAT vtr2 = vt2 - (delx*wr3-delz*wr1);
+      V_FLOAT vtr3 = vt3 - (dely*wr1-delx*wr2);
+      V_FLOAT vrel = vtr1*vtr1 + vtr2*vtr2 + vtr3*vtr3;
+      vrel = sqrt(vrel);
+
+      // force normalization
+      F_FLOAT fn = xmu*fabs(ccel*r);
+      F_FLOAT fs = meff*gammat*vrel;
+      F_FLOAT ft = 0.0;
+      if (vrel != 0.0) ft = MIN(fn,fs) / vrel;
+
+      // tangential force due to tangential velocity damping
+      F_FLOAT fs1 = -ft*vtr1;
+      F_FLOAT fs2 = -ft*vtr2;
+      F_FLOAT fs3 = -ft*vtr3;
+
+      // forces & torques
+      F_FLOAT fx = delx*ccel + fs1;
+      F_FLOAT fy = dely*ccel + fs2;
+      F_FLOAT fz = delz*ccel + fs3;
+      fx_i += fx;
+      fy_i += fy;
+      fz_i += fz;
+
+      F_FLOAT tor1 = rinv * (dely*fs3 - delz*fs2);
+      F_FLOAT tor2 = rinv * (delz*fs1 - delx*fs3);
+      F_FLOAT tor3 = rinv * (delx*fs2 - dely*fs1);
+      torquex_i -= irad*tor1;
+      torquey_i -= irad*tor2;
+      torquez_i -= irad*tor3;
+      
+      if (NEWTON_PAIR || j < nlocal) {
+        a_f(j,0) -= fx;
+        a_f(j,1) -= fy;
+        a_f(j,2) -= fz;
+        a_torque(j,0) -= jrad*tor1;
+        a_torque(j,1) -= jrad*tor2;
+        a_torque(j,2) -= jrad*tor3;
+      }
+
+      if (EVFLAG == 2)
+        ev_tally_xyz_atom<NEIGHFLAG, NEWTON_PAIR>(ev, i, j, fx_i, fy_i, fz_i, delx, dely, delz);
+      if (EVFLAG == 1)
+        ev_tally_xyz<NEWTON_PAIR>(ev, i, j, fx_i, fy_i, fz_i, delx, dely, delz);
+    }
+  }
+
+  a_f(i,0) += fx_i;
+  a_f(i,1) += fy_i;
+  a_f(i,2) += fz_i;
+  a_torque(i,0) += torquex_i;
+  a_torque(i,1) += torquey_i;
+  a_torque(i,2) += torquez_i;
+}
+
+
+template<class DeviceType>
+template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void PairGranHookeKokkos<DeviceType>::operator()(TagPairGranHookeCompute<NEIGHFLAG,NEWTON_PAIR,EVFLAG>, const int ii) const {
+  EV_FLOAT ev;
+  this->template operator()<NEIGHFLAG,NEWTON_PAIR,EVFLAG>(TagPairGranHookeCompute<NEIGHFLAG,NEWTON_PAIR,EVFLAG>(), ii, ev);
+}
+
+template<class DeviceType>
+template<int NEWTON_PAIR>
+KOKKOS_INLINE_FUNCTION
+void PairGranHookeKokkos<DeviceType>::ev_tally_xyz(EV_FLOAT &ev, int i, int j,
+		                                   F_FLOAT fx, F_FLOAT fy, F_FLOAT fz,
+		                                   X_FLOAT delx, X_FLOAT dely, X_FLOAT delz) const
+{
+  F_FLOAT v[6];
+
+  v[0] = delx*fx;
+  v[1] = dely*fy;
+  v[2] = delz*fz;
+  v[3] = delx*fy;
+  v[4] = delx*fz;
+  v[5] = dely*fz;
+
+  if (NEWTON_PAIR) {
+    ev.v[0] += v[0];
+    ev.v[1] += v[1];
+    ev.v[2] += v[2];
+    ev.v[3] += v[3];
+    ev.v[4] += v[4];
+    ev.v[5] += v[5];
+  } else {
+    if (i < nlocal) {
+      ev.v[0] += 0.5*v[0];
+      ev.v[1] += 0.5*v[1];
+      ev.v[2] += 0.5*v[2];
+      ev.v[3] += 0.5*v[3];
+      ev.v[4] += 0.5*v[4];
+      ev.v[5] += 0.5*v[5];
+    }
+    if (j < nlocal) {
+      ev.v[0] += 0.5*v[0];
+      ev.v[1] += 0.5*v[1];
+      ev.v[2] += 0.5*v[2];
+      ev.v[3] += 0.5*v[3];
+      ev.v[4] += 0.5*v[4];
+      ev.v[5] += 0.5*v[5];
+    }
+  }
+}
+
+template<class DeviceType>
+template<int NEIGHFLAG, int NEWTON_PAIR>
+KOKKOS_INLINE_FUNCTION
+void PairGranHookeKokkos<DeviceType>::ev_tally_xyz_atom(EV_FLOAT &ev, int i, int j,
+		                                        F_FLOAT fx, F_FLOAT fy, F_FLOAT fz,
+						        X_FLOAT delx, X_FLOAT dely, X_FLOAT delz) const
+{
+  Kokkos::View<F_FLOAT*[6], typename DAT::t_virial_array::array_layout,DeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > v_vatom = k_vatom.view<DeviceType>();  
+
+  F_FLOAT v[6];
+
+  v[0] = delx*fx;
+  v[1] = dely*fy;
+  v[2] = delz*fz;
+  v[3] = delx*fy;
+  v[4] = delx*fz;
+  v[5] = dely*fz;
+
+  if (NEWTON_PAIR || i < nlocal) {
+    v_vatom(i,0) += 0.5*v[0];
+    v_vatom(i,1) += 0.5*v[1];
+    v_vatom(i,2) += 0.5*v[2];
+    v_vatom(i,3) += 0.5*v[3];
+    v_vatom(i,4) += 0.5*v[4];
+    v_vatom(i,5) += 0.5*v[5];
+  }
+  if (NEWTON_PAIR || j < nlocal) {
+    v_vatom(j,0) += 0.5*v[0];
+    v_vatom(j,1) += 0.5*v[1];
+    v_vatom(j,2) += 0.5*v[2];
+    v_vatom(j,3) += 0.5*v[3];
+    v_vatom(j,4) += 0.5*v[4];
+    v_vatom(j,5) += 0.5*v[5];
+  }
+}
+
+namespace LAMMPS_NS {
+template class PairGranHookeKokkos<LMPDeviceType>;
+#ifdef KOKKOS_HAVE_CUDA
+template class PairGranHookeKokkos<LMPHostType>;
+#endif
+}

--- a/src/KOKKOS/pair_gran_hooke_kokkos.h
+++ b/src/KOKKOS/pair_gran_hooke_kokkos.h
@@ -1,0 +1,138 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+
+PairStyle(gran/hooke/kk,PairGranHookeKokkos<LMPDeviceType>)
+PairStyle(gran/hooke/kk/device,PairGranHookeKokkos<LMPDeviceType>)
+PairStyle(gran/hooke/kk/host,PairGranHookeKokkos<LMPHostType>)
+
+#else
+
+#ifndef LMP_PAIR_GRAN_HOOKE_KOKKOS_H
+#define LMP_PAIR_GRAN_HOOKE_KOKKOS_H
+
+#include "pair_gran_hooke.h"
+#include "pair_kokkos.h"
+#include "kokkos_type.h"
+
+namespace LAMMPS_NS {
+
+template <class DeviceType>
+class FixNeighHistoryKokkos;
+  
+template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
+struct TagPairGranHookeCompute {};
+
+template <class DeviceType>
+class PairGranHookeKokkos : public PairGranHooke {
+ public:
+  typedef DeviceType device_type;
+  typedef ArrayTypes<DeviceType> AT;
+  typedef EV_FLOAT value_type;
+
+  PairGranHookeKokkos(class LAMMPS *);
+  virtual ~PairGranHookeKokkos();
+  virtual void compute(int, int);
+  void init_style();
+
+  template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagPairGranHookeCompute<NEIGHFLAG,NEWTON_PAIR,EVFLAG>, const int, EV_FLOAT &ev) const;
+  template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagPairGranHookeCompute<NEIGHFLAG,NEWTON_PAIR,EVFLAG>, const int) const;
+
+  template<int NEWTON_PAIR>
+  KOKKOS_INLINE_FUNCTION
+  void ev_tally_xyz(EV_FLOAT &ev, int i, int j,
+		    F_FLOAT fx, F_FLOAT fy, F_FLOAT fz,
+		    X_FLOAT delx, X_FLOAT dely, X_FLOAT delz) const;
+  template<int NEIGHFLAG, int NEWTON_PAIR>
+  KOKKOS_INLINE_FUNCTION
+  void ev_tally_xyz_atom(EV_FLOAT &ev, int i, int j,
+			 F_FLOAT fx, F_FLOAT fy, F_FLOAT fz,
+			 X_FLOAT delx, X_FLOAT dely, X_FLOAT delz) const;
+    
+ protected:
+  typename AT::t_x_array_randomread x;
+  typename AT::t_x_array c_x;
+  typename AT::t_v_array_randomread v;
+  typename AT::t_v_array_randomread omega;
+  typename AT::t_f_array f;
+  typename AT::t_f_array torque;
+  typename AT::t_int_1d_randomread type;
+  typename AT::t_int_1d_randomread mask;
+  typename AT::t_float_1d_randomread rmass;
+  typename AT::t_float_1d_randomread radius;
+
+  DAT::tdual_efloat_1d k_eatom;
+  DAT::tdual_virial_array k_vatom;
+  typename AT::t_efloat_1d d_eatom;
+  typename AT::t_virial_array d_vatom;
+  typename AT::t_tagint_1d tag;
+
+  typename AT::t_neighbors_2d d_neighbors;
+  typename AT::t_int_1d_randomread d_ilist;
+  typename AT::t_int_1d_randomread d_numneigh;
+
+  int newton_pair;
+
+  int neighflag;
+  int nlocal,nall,eflag,vflag;
+
+  FixNeighHistoryKokkos<DeviceType> *fix_historyKK;
+
+  friend void pair_virial_fdotr_compute<PairGranHookeKokkos>(PairGranHookeKokkos*);
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: Incorrect args for pair coefficients
+
+Self-explanatory.  Check the input script or data file.
+
+E: Pair granular requires atom attributes radius, rmass
+
+The atom style defined does not have these attributes.
+
+E: Pair granular requires ghost atoms store velocity
+
+Use the comm_modify vel yes command to enable this.
+
+E: Could not find pair fix neigh history ID
+
+UNDOCUMENTED
+
+U: Pair granular with shear history requires newton pair off
+
+This is a current restriction of the implementation of pair
+granular styles with history.
+
+U: Could not find pair fix ID
+
+A fix is created internally by the pair style to store shear
+history information.  You cannot delete it.
+
+*/

--- a/src/KOKKOS/pair_gran_hooke_thickness_kokkos.cpp
+++ b/src/KOKKOS/pair_gran_hooke_thickness_kokkos.cpp
@@ -1,0 +1,444 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_gran_hooke_thickness_kokkos.h"
+#include "kokkos.h"
+#include "atom_kokkos.h"
+#include "atom_masks.h"
+#include "memory_kokkos.h"
+#include "force.h"
+#include "neighbor.h"
+#include "neigh_list.h"
+#include "neigh_request.h"
+#include "error.h"
+#include "modify.h"
+#include "fix_neigh_history_kokkos.h"
+#include "update.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+PairGranHookeThicknessKokkos<DeviceType>::PairGranHookeThicknessKokkos(LAMMPS *lmp) : PairGranHookeThickness(lmp)
+{
+  atomKK = (AtomKokkos *) atom;
+  execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
+  datamask_read = X_MASK | V_MASK | OMEGA_MASK | F_MASK | TORQUE_MASK | TYPE_MASK | 
+                  MASK_MASK | ENERGY_MASK | VIRIAL_MASK | RMASS_MASK | RADIUS_MASK | THICKNESS_MASK;
+  datamask_modify = F_MASK | TORQUE_MASK | ENERGY_MASK | VIRIAL_MASK;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+PairGranHookeThicknessKokkos<DeviceType>::~PairGranHookeThicknessKokkos()
+{
+  if (copymode) return;
+
+  if (allocated) {
+    memoryKK->destroy_kokkos(k_eatom,eatom);
+    memoryKK->destroy_kokkos(k_vatom,vatom);
+    eatom = NULL;
+    vatom = NULL;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   init specific to this pair style
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+void PairGranHookeThicknessKokkos<DeviceType>::init_style()
+{
+  if (history && fix_history == NULL) {
+    char dnumstr[16];
+    sprintf(dnumstr,"%d",3);
+    char **fixarg = new char*[4];
+    fixarg[0] = (char *) "NEIGH_HISTORY";
+    fixarg[1] = (char *) "all";
+    if (execution_space == Device)
+      fixarg[2] = (char *) "NEIGH_HISTORY/KK/DEVICE";
+    else
+      fixarg[2] = (char *) "NEIGH_HISTORY/KK/HOST";
+    fixarg[3] = dnumstr;
+    modify->add_fix(4,fixarg,1);
+    delete [] fixarg;
+    fix_history = (FixNeighHistory *) modify->fix[modify->nfix-1];
+    fix_history->pair = this;
+    fix_historyKK = (FixNeighHistoryKokkos<DeviceType> *)fix_history;
+  }
+
+  PairGranHookeHistory::init_style();
+
+  // irequest = neigh request made by parent class
+
+  neighflag = lmp->kokkos->neighflag;
+  int irequest = neighbor->nrequest - 1;
+
+  neighbor->requests[irequest]->
+    kokkos_host = Kokkos::Impl::is_same<DeviceType,LMPHostType>::value &&
+    !Kokkos::Impl::is_same<DeviceType,LMPDeviceType>::value;
+  neighbor->requests[irequest]->
+    kokkos_device = Kokkos::Impl::is_same<DeviceType,LMPDeviceType>::value;
+
+  if (neighflag == HALF || neighflag == HALFTHREAD) {
+    neighbor->requests[irequest]->full = 0;
+    neighbor->requests[irequest]->half = 1;
+  } else {
+    error->all(FLERR,"Cannot use chosen neighbor list style with gran/hooke/kk");
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void PairGranHookeThicknessKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
+{
+  copymode = 1;
+
+  eflag = eflag_in;
+  vflag = vflag_in;
+
+  if (neighflag == FULL) no_virial_fdotr_compute = 1;
+
+  if (eflag || vflag) ev_setup(eflag,vflag,0);
+  else evflag = vflag_fdotr = 0;
+
+  // reallocate per-atom arrays if necessary
+
+  if (eflag_atom) {
+    memoryKK->destroy_kokkos(k_eatom,eatom);
+    memoryKK->create_kokkos(k_eatom,eatom,maxeatom,"pair:eatom");
+    d_eatom = k_eatom.view<DeviceType>();
+  }
+  if (vflag_atom) {
+    memoryKK->destroy_kokkos(k_vatom,vatom);
+    memoryKK->create_kokkos(k_vatom,vatom,maxvatom,6,"pair:vatom");
+    d_vatom = k_vatom.view<DeviceType>();
+  }
+
+  atomKK->sync(execution_space,datamask_read);
+  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
+  else atomKK->modified(execution_space,F_MASK | TORQUE_MASK);
+
+  x = atomKK->k_x.view<DeviceType>();
+  v = atomKK->k_v.view<DeviceType>();
+  omega = atomKK->k_omega.view<DeviceType>();
+  f = atomKK->k_f.view<DeviceType>();
+  torque = atomKK->k_torque.view<DeviceType>();
+  type = atomKK->k_type.view<DeviceType>();
+  mask = atomKK->k_mask.view<DeviceType>();
+  tag = atomKK->k_tag.view<DeviceType>();
+  rmass = atomKK->k_rmass.view<DeviceType>();
+  radius = atomKK->k_radius.view<DeviceType>();
+  mean_thickness = atomKK->k_mean_thickness.view<DeviceType>();
+  nlocal = atom->nlocal;
+  nall = atom->nlocal + atom->nghost;
+  newton_pair = force->newton_pair;
+
+  int inum = list->inum;
+  NeighListKokkos<DeviceType>* k_list = static_cast<NeighListKokkos<DeviceType>*>(list);
+  d_numneigh = k_list->d_numneigh;
+  d_neighbors = k_list->d_neighbors;
+  d_ilist = k_list->d_ilist;
+
+  EV_FLOAT ev;
+
+  if (lmp->kokkos->neighflag == HALF) {
+    if (force->newton_pair) {
+      if (vflag_atom) {
+         Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeThicknessCompute<HALF,1,2>>(0,inum),*this);
+      } else if (vflag_global) {
+         Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairGranHookeThicknessCompute<HALF,1,1>>(0,inum),*this, ev);
+      } else {
+         Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeThicknessCompute<HALF,1,0>>(0,inum),*this);
+      }
+    } else {
+      if (vflag_atom) {
+	Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeThicknessCompute<HALF,0,2>>(0,inum),*this);
+      } else if (vflag_global) {
+	Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairGranHookeThicknessCompute<HALF,0,1>>(0,inum),*this, ev);
+      } else {
+        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeThicknessCompute<HALF,0,0>>(0,inum),*this);
+      }
+    }
+  } else { // HALFTHREAD
+    if (force->newton_pair) {
+      if (vflag_atom) {
+        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeThicknessCompute<HALFTHREAD,1,2>>(0,inum),*this);
+      } else if (vflag_global) {
+	Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairGranHookeThicknessCompute<HALFTHREAD,1,1>>(0,inum),*this, ev);
+      } else {
+        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeThicknessCompute<HALFTHREAD,1,0>>(0,inum),*this);
+      }
+    } else {
+      if (vflag_atom) {
+	Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeThicknessCompute<HALFTHREAD,0,2>>(0,inum),*this);
+      } else if (vflag_global) {
+	Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairGranHookeThicknessCompute<HALFTHREAD,0,1>>(0,inum),*this, ev);
+      } else {
+	Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairGranHookeThicknessCompute<HALFTHREAD,0,0>>(0,inum),*this);
+      }
+    }
+  }
+
+  if (vflag_global) {
+    virial[0] += ev.v[0];
+    virial[1] += ev.v[1];
+    virial[2] += ev.v[2];
+    virial[3] += ev.v[3];
+    virial[4] += ev.v[4];
+    virial[5] += ev.v[5];
+  }
+
+  if (vflag_atom) {
+    k_vatom.template modify<DeviceType>();
+    k_vatom.template sync<LMPHostType>();
+  }
+
+  if (vflag_fdotr) pair_virial_fdotr_compute(this);
+
+  copymode = 0;
+}
+
+template<class DeviceType>
+template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void PairGranHookeThicknessKokkos<DeviceType>::operator()(TagPairGranHookeThicknessCompute<NEIGHFLAG,NEWTON_PAIR,EVFLAG>, const int ii, EV_FLOAT &ev) const {
+
+  // The f and torque arrays are atomic for Half/Thread neighbor style
+  Kokkos::View<F_FLOAT*[3], typename DAT::t_f_array::array_layout,DeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > a_f = f;
+  Kokkos::View<F_FLOAT*[3], typename DAT::t_f_array::array_layout,DeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > a_torque = torque;
+
+  const int i = d_ilist[ii];
+  const X_FLOAT xtmp = x(i,0);
+  const X_FLOAT ytmp = x(i,1);
+  const X_FLOAT ztmp = x(i,2);
+  const LMP_FLOAT irad = radius(i);
+  const LMP_FLOAT imass = rmass(i);
+  const int jnum = d_numneigh(i);
+  
+  F_FLOAT fx_i = 0.0;
+  F_FLOAT fy_i = 0.0;
+  F_FLOAT fz_i = 0.0;
+
+  F_FLOAT torquex_i = 0.0;
+  F_FLOAT torquey_i = 0.0;
+  F_FLOAT torquez_i = 0.0;
+
+  for (int jj = 0; jj < jnum; jj++) {
+    int j = d_neighbors(i,jj);
+    j &= NEIGHMASK;
+    
+    const X_FLOAT delx = xtmp - x(j,0);
+    const X_FLOAT dely = ytmp - x(j,1);
+    const X_FLOAT delz = ztmp - x(j,2);
+    const X_FLOAT rsq = delx*delx + dely*dely + delz*delz;
+    const LMP_FLOAT jrad = radius(j);
+    const LMP_FLOAT jmass = rmass(j);
+    const LMP_FLOAT radsum = irad + jrad;
+
+    // check for touching neighbors
+    if (rsq < radsum*radsum) {
+
+      const LMP_FLOAT r = sqrt(rsq);
+      const LMP_FLOAT rinv = 1.0/r;
+      const LMP_FLOAT rsqinv = 1/rsq;
+
+      // relative translational velocity
+      V_FLOAT vr1 = v(i,0) - v(j,0);
+      V_FLOAT vr2 = v(i,1) - v(j,1);
+      V_FLOAT vr3 = v(i,2) - v(j,2);
+      
+      // normal component
+      V_FLOAT vnnr = vr1*delx + vr2*dely + vr3*delz;
+      V_FLOAT vn1 = delx*vnnr * rsqinv;
+      V_FLOAT vn2 = dely*vnnr * rsqinv;
+      V_FLOAT vn3 = delz*vnnr * rsqinv;
+      
+      // tangential component
+      V_FLOAT vt1 = vr1 - vn1;
+      V_FLOAT vt2 = vr2 - vn2;
+      V_FLOAT vt3 = vr3 - vn3;
+
+      // relative rotational velocity
+      V_FLOAT wr1 = (irad*omega(i,0) + jrad*omega(j,0)) * rinv;
+      V_FLOAT wr2 = (irad*omega(i,1) + jrad*omega(j,1)) * rinv;
+      V_FLOAT wr3 = (irad*omega(i,2) + jrad*omega(j,2)) * rinv;
+
+      // meff = effective mass of pair of particles
+      // if I or J part of rigid body, use body mass
+      // if I or J is frozen, meff is other particle
+      LMP_FLOAT meff = imass*jmass / (imass+jmass);
+      if (mask[i] & freeze_group_bit) meff = jmass;
+      if (mask[j] & freeze_group_bit) meff = imass;
+
+      F_FLOAT min_thick = MIN(mean_thickness(i),mean_thickness(j));
+
+      // normal forces = Hookian contact + normal velocity damping
+      F_FLOAT damp = meff*gamman*vnnr*rsqinv;
+      F_FLOAT ccel = min_thick*kn*(radsum-r)*rinv - damp;
+
+      // relative velocities
+      V_FLOAT vtr1 = vt1 - (delz*wr2-dely*wr3);
+      V_FLOAT vtr2 = vt2 - (delx*wr3-delz*wr1);
+      V_FLOAT vtr3 = vt3 - (dely*wr1-delx*wr2);
+      V_FLOAT vrel = vtr1*vtr1 + vtr2*vtr2 + vtr3*vtr3;
+      vrel = sqrt(vrel);
+
+      // force normalization
+      F_FLOAT fn = xmu*fabs(ccel*r);
+      F_FLOAT fs = meff*min_thick*gammat*vrel;
+      F_FLOAT ft = 0.0;
+      if (vrel != 0.0) ft = MIN(fn,fs) / vrel;
+
+      // tangential force due to tangential velocity damping
+      F_FLOAT fs1 = -ft*vtr1;
+      F_FLOAT fs2 = -ft*vtr2;
+      F_FLOAT fs3 = -ft*vtr3;
+
+      // forces & torques
+      F_FLOAT fx = delx*ccel + fs1;
+      F_FLOAT fy = dely*ccel + fs2;
+      F_FLOAT fz = delz*ccel + fs3;
+      fx_i += fx;
+      fy_i += fy;
+      fz_i += fz;
+
+      F_FLOAT tor1 = rinv * (dely*fs3 - delz*fs2);
+      F_FLOAT tor2 = rinv * (delz*fs1 - delx*fs3);
+      F_FLOAT tor3 = rinv * (delx*fs2 - dely*fs1);
+      torquex_i -= irad*tor1;
+      torquey_i -= irad*tor2;
+      torquez_i -= irad*tor3;
+      
+      if (NEWTON_PAIR || j < nlocal) {
+        a_f(j,0) -= fx;
+        a_f(j,1) -= fy;
+        a_f(j,2) -= fz;
+        a_torque(j,0) -= jrad*tor1;
+        a_torque(j,1) -= jrad*tor2;
+        a_torque(j,2) -= jrad*tor3;
+      }
+
+      if (EVFLAG == 2)
+        ev_tally_xyz_atom<NEIGHFLAG, NEWTON_PAIR>(ev, i, j, fx_i, fy_i, fz_i, delx, dely, delz);
+      if (EVFLAG == 1)
+        ev_tally_xyz<NEWTON_PAIR>(ev, i, j, fx_i, fy_i, fz_i, delx, dely, delz);
+    }
+  }
+
+  a_f(i,0) += fx_i;
+  a_f(i,1) += fy_i;
+  a_f(i,2) += fz_i;
+  a_torque(i,0) += torquex_i;
+  a_torque(i,1) += torquey_i;
+  a_torque(i,2) += torquez_i;
+
+}
+
+
+template<class DeviceType>
+template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void PairGranHookeThicknessKokkos<DeviceType>::operator()(TagPairGranHookeThicknessCompute<NEIGHFLAG,NEWTON_PAIR,EVFLAG>, const int ii) const {
+  EV_FLOAT ev;
+  this->template operator()<NEIGHFLAG,NEWTON_PAIR,EVFLAG>(TagPairGranHookeThicknessCompute<NEIGHFLAG,NEWTON_PAIR,EVFLAG>(), ii, ev);
+}
+
+template<class DeviceType>
+template<int NEWTON_PAIR>
+KOKKOS_INLINE_FUNCTION
+void PairGranHookeThicknessKokkos<DeviceType>::ev_tally_xyz(EV_FLOAT &ev, int i, int j,
+		                                   F_FLOAT fx, F_FLOAT fy, F_FLOAT fz,
+		                                   X_FLOAT delx, X_FLOAT dely, X_FLOAT delz) const
+{
+  F_FLOAT v[6];
+
+  v[0] = delx*fx;
+  v[1] = dely*fy;
+  v[2] = delz*fz;
+  v[3] = delx*fy;
+  v[4] = delx*fz;
+  v[5] = dely*fz;
+
+  if (NEWTON_PAIR) {
+    ev.v[0] += v[0];
+    ev.v[1] += v[1];
+    ev.v[2] += v[2];
+    ev.v[3] += v[3];
+    ev.v[4] += v[4];
+    ev.v[5] += v[5];
+  } else {
+    if (i < nlocal) {
+      ev.v[0] += 0.5*v[0];
+      ev.v[1] += 0.5*v[1];
+      ev.v[2] += 0.5*v[2];
+      ev.v[3] += 0.5*v[3];
+      ev.v[4] += 0.5*v[4];
+      ev.v[5] += 0.5*v[5];
+    }
+    if (j < nlocal) {
+      ev.v[0] += 0.5*v[0];
+      ev.v[1] += 0.5*v[1];
+      ev.v[2] += 0.5*v[2];
+      ev.v[3] += 0.5*v[3];
+      ev.v[4] += 0.5*v[4];
+      ev.v[5] += 0.5*v[5];
+    }
+  }
+}
+
+template<class DeviceType>
+template<int NEIGHFLAG, int NEWTON_PAIR>
+KOKKOS_INLINE_FUNCTION
+void PairGranHookeThicknessKokkos<DeviceType>::ev_tally_xyz_atom(EV_FLOAT &ev, int i, int j,
+		                                                F_FLOAT fx, F_FLOAT fy, F_FLOAT fz,
+					            	        X_FLOAT delx, X_FLOAT dely, X_FLOAT delz) const
+{
+  Kokkos::View<F_FLOAT*[6], typename DAT::t_virial_array::array_layout,DeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > v_vatom = k_vatom.view<DeviceType>();  
+
+  F_FLOAT v[6];
+
+  v[0] = delx*fx;
+  v[1] = dely*fy;
+  v[2] = delz*fz;
+  v[3] = delx*fy;
+  v[4] = delx*fz;
+  v[5] = dely*fz;
+
+  if (NEWTON_PAIR || i < nlocal) {
+    v_vatom(i,0) += 0.5*v[0];
+    v_vatom(i,1) += 0.5*v[1];
+    v_vatom(i,2) += 0.5*v[2];
+    v_vatom(i,3) += 0.5*v[3];
+    v_vatom(i,4) += 0.5*v[4];
+    v_vatom(i,5) += 0.5*v[5];
+  }
+  if (NEWTON_PAIR || j < nlocal) {
+    v_vatom(j,0) += 0.5*v[0];
+    v_vatom(j,1) += 0.5*v[1];
+    v_vatom(j,2) += 0.5*v[2];
+    v_vatom(j,3) += 0.5*v[3];
+    v_vatom(j,4) += 0.5*v[4];
+    v_vatom(j,5) += 0.5*v[5];
+  }
+}
+
+namespace LAMMPS_NS {
+template class PairGranHookeThicknessKokkos<LMPDeviceType>;
+#ifdef KOKKOS_HAVE_CUDA
+template class PairGranHookeThicknessKokkos<LMPHostType>;
+#endif
+}

--- a/src/KOKKOS/pair_gran_hooke_thickness_kokkos.h
+++ b/src/KOKKOS/pair_gran_hooke_thickness_kokkos.h
@@ -1,0 +1,139 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+
+PairStyle(gran/hooke/thickness/kk,PairGranHookeThicknessKokkos<LMPDeviceType>)
+PairStyle(gran/hooke/thickness/kk/device,PairGranHookeThicknessKokkos<LMPDeviceType>)
+PairStyle(gran/hooke/thickness/kk/host,PairGranHookeThicknessKokkos<LMPHostType>)
+
+#else
+
+#ifndef LMP_PAIR_GRAN_HOOKE_THICKNESS_KOKKOS_H
+#define LMP_PAIR_GRAN_HOOKE_THICKNESS_KOKKOS_H
+
+#include "pair_gran_hooke_thickness.h"
+#include "pair_kokkos.h"
+#include "kokkos_type.h"
+
+namespace LAMMPS_NS {
+
+template <class DeviceType>
+class FixNeighHistoryKokkos;
+  
+template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
+struct TagPairGranHookeThicknessCompute {};
+
+template <class DeviceType>
+class PairGranHookeThicknessKokkos : public PairGranHookeThickness {
+ public:
+  typedef DeviceType device_type;
+  typedef ArrayTypes<DeviceType> AT;
+  typedef EV_FLOAT value_type;
+
+  PairGranHookeThicknessKokkos(class LAMMPS *);
+  virtual ~PairGranHookeThicknessKokkos();
+  virtual void compute(int, int);
+  void init_style();
+
+  template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagPairGranHookeThicknessCompute<NEIGHFLAG,NEWTON_PAIR,EVFLAG>, const int, EV_FLOAT &ev) const;
+  template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagPairGranHookeThicknessCompute<NEIGHFLAG,NEWTON_PAIR,EVFLAG>, const int) const;
+
+  template<int NEWTON_PAIR>
+  KOKKOS_INLINE_FUNCTION
+  void ev_tally_xyz(EV_FLOAT &ev, int i, int j,
+		    F_FLOAT fx, F_FLOAT fy, F_FLOAT fz,
+		    X_FLOAT delx, X_FLOAT dely, X_FLOAT delz) const;
+  template<int NEIGHFLAG, int NEWTON_PAIR>
+  KOKKOS_INLINE_FUNCTION
+  void ev_tally_xyz_atom(EV_FLOAT &ev, int i, int j,
+			 F_FLOAT fx, F_FLOAT fy, F_FLOAT fz,
+			 X_FLOAT delx, X_FLOAT dely, X_FLOAT delz) const;
+    
+ protected:
+  typename AT::t_x_array_randomread x;
+  typename AT::t_x_array c_x;
+  typename AT::t_v_array_randomread v;
+  typename AT::t_v_array_randomread omega;
+  typename AT::t_f_array f;
+  typename AT::t_f_array torque;
+  typename AT::t_int_1d_randomread type;
+  typename AT::t_int_1d_randomread mask;
+  typename AT::t_float_1d_randomread rmass;
+  typename AT::t_float_1d_randomread radius;
+  typename AT::t_float_1d_randomread mean_thickness;
+
+  DAT::tdual_efloat_1d k_eatom;
+  DAT::tdual_virial_array k_vatom;
+  typename AT::t_efloat_1d d_eatom;
+  typename AT::t_virial_array d_vatom;
+  typename AT::t_tagint_1d tag;
+
+  typename AT::t_neighbors_2d d_neighbors;
+  typename AT::t_int_1d_randomread d_ilist;
+  typename AT::t_int_1d_randomread d_numneigh;
+
+  int newton_pair;
+
+  int neighflag;
+  int nlocal,nall,eflag,vflag;
+
+  FixNeighHistoryKokkos<DeviceType> *fix_historyKK;
+
+  friend void pair_virial_fdotr_compute<PairGranHookeThicknessKokkos>(PairGranHookeThicknessKokkos*);
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: Incorrect args for pair coefficients
+
+Self-explanatory.  Check the input script or data file.
+
+E: Pair granular requires atom attributes radius, rmass
+
+The atom style defined does not have these attributes.
+
+E: Pair granular requires ghost atoms store velocity
+
+Use the comm_modify vel yes command to enable this.
+
+E: Could not find pair fix neigh history ID
+
+UNDOCUMENTED
+
+U: Pair granular with shear history requires newton pair off
+
+This is a current restriction of the implementation of pair
+granular styles with history.
+
+U: Could not find pair fix ID
+
+A fix is created internally by the pair style to store shear
+history information.  You cannot delete it.
+
+*/


### PR DESCRIPTION
Convert gran/hooke and gran/hooke/thickness contact models to Kokkos.
Convert fix/nve/sphere/demsi, used in semi-implicit integration to Kokkos.

Bug fixes in atom/vec/demsi and fix/neigh/history. 

The change in fix/neigh/history enables the cantilever beam test cases to run
correctly on GPUs without all the sync statements in DEMSI pull request #155.

However, the vortex solutions are now slightly different depending on number of threads and number of processors. Until this is resolved  - do not merge.

