### PR TITLE
Changed elastic force for ridging force

### DIFF
--- a/src/KOKKOS/pair_gran_hopkins_kokkos.cpp
+++ b/src/KOKKOS/pair_gran_hopkins_kokkos.cpp
@@ -369,7 +369,7 @@ void PairGranHopkinsKokkos<DeviceType>::elastic_stiffness(F_FLOAT meanIceThickne
 
   F_FLOAT stiffness1 = (Emod * meanIceThickness1) / (2.0 * radius1);
   F_FLOAT stiffness2 = (Emod * meanIceThickness2) / (2.0 * radius2);
-  elasticStiffness = 1.0 / ((1.0 / stiffness1) + (1.0 / stiffness2));
+  elasticStiffness = std::min(stiffness1,stiffness2);
 
 }
 


### PR DESCRIPTION
## Purpose

Modifies the elasticity for ridging by making the used thickness the lesser of the two elements thickness rather than the harmonic mean.

## Author(s)

Adrian K. Turner, LANL

## Backward Compatibility

Not BFB

## Implementation Notes

elasticity for ridging by making the used thickness the lesser of the two elements thickness rather than the harmonic mean.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


