### PR TITLE
update cuda flags for pair_gran_hopkins_kokkos and fix_addforce_kokkos

### DIFF
--- a/src/KOKKOS/fix_addforce_kokkos.cpp
+++ b/src/KOKKOS/fix_addforce_kokkos.cpp
@@ -266,7 +266,7 @@ void FixAddForceKokkos<DeviceType>::operator()(TagFixAddForceNonConstant, const 
 
 namespace LAMMPS_NS {
 template class FixAddForceKokkos<LMPDeviceType>;
-#ifdef KOKKOS_HAVE_CUDA
+#ifdef KOKKOS_ENABLE_CUDA
 template class FixAddForceKokkos<LMPHostType>;
 #endif
 }

--- a/src/KOKKOS/pair_gran_hopkins_kokkos.cpp
+++ b/src/KOKKOS/pair_gran_hopkins_kokkos.cpp
@@ -1243,7 +1243,7 @@ void PairGranHopkinsKokkos<DeviceType>::ev_tally_xyz_atom(EV_FLOAT &ev, int i, i
 
 namespace LAMMPS_NS {
 template class PairGranHopkinsKokkos<LMPDeviceType>;
-#ifdef KOKKOS_HAVE_CUDA
+#ifdef KOKKOS_ENABLE_CUDA
 template class PairGranHopkinsKokkos<LMPHostType>;
 #endif
 }


### PR DESCRIPTION
**Summary**

Change cuda flag from KOKKOS_HAVE_CUDA to KOKKOS_ENABLE_CUDA

**Related Issues**

Without this flag you will encounter linker errors when building lammps as a shared library with coda

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Change is not backward compatible with previous version of lammps.



