### PR TITLE
Add updates for BFB restarts in LAMMPS

### DIFF
--- a/src/fix_neigh_history.cpp
+++ b/src/fix_neigh_history.cpp
@@ -40,6 +40,7 @@ FixNeighHistory::FixNeighHistory(LAMMPS *lmp, int narg, char **arg) :
   if (narg != 4) error->all(FLERR,"Illegal fix NEIGH_HISTORY command");
 
   restart_peratom = 1;
+  restart_global = 1;
   create_attribute = 1;
   maxexchange_dynamic = 1;
 
@@ -842,6 +843,22 @@ int FixNeighHistory::unpack_exchange(int nlocal, double *buf)
     m += dnum;
   }
   return m;
+}
+
+/* ----------------------------------------------------------------------
+   Use write_restart to invoke pre_exchange
+------------------------------------------------------------------------- */
+
+void FixNeighHistory::write_restart(FILE *fp)
+{
+  // Call pre-exchange to copy updated history in page file
+  // back into per-atom arrays prior to packing restart data
+
+  pre_exchange();
+  if (comm->me == 0) {
+    int size = 0;
+    fwrite(&size,sizeof(int),1,fp);
+  }  
 }
 
 /* ----------------------------------------------------------------------

--- a/src/fix_neigh_history.h
+++ b/src/fix_neigh_history.h
@@ -56,6 +56,7 @@ class FixNeighHistory : public Fix {
   void unpack_reverse_comm(int, int *, double *);
   int pack_exchange(int, double *);
   int unpack_exchange(int, double *);
+  void write_restart(FILE *);
   int pack_restart(int, double *);
   void unpack_restart(int, int);
   int size_restart(int);

--- a/src/fix_restart_forces.cpp
+++ b/src/fix_restart_forces.cpp
@@ -57,8 +57,8 @@ FixRestartForces::~FixRestartForces()
 
 void FixRestartForces::post_constructor()
 {
-  //Alternatively, could use a locl rray. But in setup its possible atoms can be sorted
-  //So I'd need to register grow and restart call backs anyway. 
+  //Alternatively, one could use a local array but atoms could be sorted in setup
+  //One would also need to register grow and restart callbacks
   int n = strlen(id) + strlen("_restart_forces") + 1;
   id_fix = new char[n];
   strcpy(id_fix,id);
@@ -97,7 +97,8 @@ int FixRestartForces::setmask()
 
 void FixRestartForces::setup(int vflag)
 {
-  if(fix->restart_reset){ // Flagged in fix/store as it restarts peratom info
+  // Check if values in fix store were loaded from  restart file
+  if(fix->restart_reset){ 
     double **f = atom->f;
     double **torque = atom->torque;
     double **values = fix->astore;
@@ -105,8 +106,6 @@ void FixRestartForces::setup(int vflag)
     int nlocal = atom->nlocal;
     int i,m;
 
-    // Note atoms may be sorted in setup, so check first
-    // Maybe I should just convert to use fix/store
     for (i = 0; i < nlocal; i++) {
       if (mask[i] & groupbit) {
         for (m = 0; m < 3; m++) {

--- a/src/fix_restart_forces.cpp
+++ b/src/fix_restart_forces.cpp
@@ -1,0 +1,145 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include <stdlib.h>
+#include <string.h>
+#include "fix_restart_forces.h"
+#include "atom.h"
+#include "group.h"
+#include "modify.h"
+#include "domain.h"
+#include "fix.h"
+#include "input.h"
+#include "memory.h"
+#include "update.h"
+#include "output.h"
+#include "error.h"
+#include "fix_store.h"
+
+using namespace LAMMPS_NS;
+using namespace FixConst;
+
+
+/* ---------------------------------------------------------------------- */
+
+FixRestartForces::FixRestartForces(LAMMPS *lmp, int narg, char **arg) :
+  Fix(lmp, narg, arg),
+  id_fix(NULL)
+{
+  if (narg != 3) error->all(FLERR,"Illegal fix restart/forces command");
+
+  // if triclinic is set, in the run setup calls to x2lamda and lamda2x will ruin bfb even with this fix
+  // Note, the addition of other fixes can easily also ruin bfb restarts for instance ones with RNG or
+  // fix/deform determines ho it strains the box based on the initial size 
+  if(domain->triclinic) 
+      error->warning(FLERR,"Triclinic box prevents bit-for-bit restarts");
+
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixRestartForces::~FixRestartForces()
+{
+  if (modify->nfix) modify->delete_fix(id_fix);    
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixRestartForces::post_constructor()
+{
+  //Alternatively, could use a locl rray. But in setup its possible atoms can be sorted
+  //So I'd need to register grow and restart call backs anyway. 
+  int n = strlen(id) + strlen("_restart_forces") + 1;
+  id_fix = new char[n];
+  strcpy(id_fix,id);
+  strcat(id_fix,"_restart_forces");
+
+  char **newarg = new char*[6];
+  newarg[0] = id_fix;
+  newarg[1] = group->names[igroup];
+  newarg[2] = (char *) "STORE";
+  newarg[3] = (char *) "peratom";
+  newarg[4] = (char *) "1";
+
+  if (atom->torque_flag) {
+    torque_flag = 1;
+    newarg[5] = (char *) "6";
+  } else {
+    newarg[5] = (char *) "3";
+  }
+
+  modify->add_fix(6,newarg);
+  fix = (FixStore *) modify->fix[modify->nfix-1];
+  delete [] newarg;  
+}
+
+
+/* ---------------------------------------------------------------------- */
+
+int FixRestartForces::setmask()
+{
+  int mask = 0;
+  mask |= END_OF_STEP;  
+  return mask;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixRestartForces::setup(int vflag)
+{
+  if(fix->restart_reset){ // Flagged in fix/store as it restarts peratom info
+    double **f = atom->f;
+    double **torque = atom->torque;
+    double **values = fix->astore;
+    int *mask = atom->mask;
+    int nlocal = atom->nlocal;
+    int i,m;
+
+    // Note atoms may be sorted in setup, so check first
+    // Maybe I should just convert to use fix/store
+    for (i = 0; i < nlocal; i++) {
+      if (mask[i] & groupbit) {
+        for (m = 0; m < 3; m++) {
+          f[i][m] = values[i][m];
+          if(torque_flag) torque[i][m] = values[i][m+3];
+        }
+      }    
+    }  
+  }
+  
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixRestartForces::end_of_step()
+{
+  if (not output->restart_flag) return;
+   
+  if(update->ntimestep == output->next_restart) {
+    double **f = atom->f;
+    double **torque = atom->torque;
+    double **values = fix->astore;     
+    int *mask = atom->mask;
+    int nlocal = atom->nlocal;
+    for(int i = 0; i < nlocal; i ++){
+      if (mask[i] & groupbit) {
+        for(int m = 0; m < 3; m++){
+          values[i][m] = f[i][m];
+          if(torque_flag) values[i][m+3] = torque[i][m];
+        }
+      }
+    } 
+  }
+}
+
+

--- a/src/fix_restart_forces.h
+++ b/src/fix_restart_forces.h
@@ -1,0 +1,45 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+
+FixStyle(restart/forces,FixRestartForces)
+
+#else
+
+#ifndef LMP_FIX_RESTART_FORCES_H
+#define LMP_FIX_RESTART_FORCES_H
+
+#include "fix.h"
+
+namespace LAMMPS_NS {
+
+class FixRestartForces : public Fix {
+ public:
+  FixRestartForces(class LAMMPS *, int, char **);
+  ~FixRestartForces();
+  void post_constructor();  
+  int setmask();
+  void setup(int);
+  void end_of_step();
+
+ private:  
+  char *id_fix;
+  class FixStore *fix;
+  int torque_flag;
+};
+
+}
+
+#endif
+#endif

--- a/src/fix_store.cpp
+++ b/src/fix_store.cpp
@@ -280,7 +280,7 @@ int FixStore::pack_restart(int i, double *buf)
     return 1;
   }
 
-  buf[0] = ubuf(nvalues+1).d;
+  buf[0] = nvalues+1;
   if (vecflag) buf[1] = vstore[i];
   else
     for (int m = 0; m < nvalues; m++)
@@ -301,7 +301,7 @@ void FixStore::unpack_restart(int nlocal, int nth)
   // skip to Nth set of extra values
 
   int m = 0;
-  for (int i = 0; i < nth; i++) m += (int) ubuf(extra[nlocal][m]).i;
+  for (int i = 0; i < nth; i++) m += static_cast<int> (extra[nlocal][m]);
   m++;
 
   if (vecflag) vstore[nlocal] = extra[nlocal][m];


### PR DESCRIPTION
Most of the changes I made to LAMMPS to ensure BFB restarts were already incorporated into DEMSI-LAMMPS when it was updated to the current LAMMPS master branch. This pull request patches two extra bugs (merged later into LAMMPS master) and adds a new fix (restart/forces).

Since LAMMPS updates velocities before writing a restart file, any force style that depends on velocity will be incorrectly computed upon restarting a simulation. Activating this fix will avoid this issue as it effectively writes forces to restart files and then reloads them. This is necessary for BFB restarts.


