### PR TITLE
Simplified Hopkins bonded contact model with orientation

### DIFF
--- a/src/KOKKOS/pair_gran_hopkins_kokkos.h
+++ b/src/KOKKOS/pair_gran_hopkins_kokkos.h
@@ -170,6 +170,7 @@ class PairGranHopkinsKokkos : public PairGranHopkins {
 
  protected:
   typename AT::t_x_array_randomread x;
+  typename AT::t_float_1d_randomread orientation;
   typename AT::t_v_array_randomread v;
   typename AT::t_v_array_randomread omega;
   typename AT::t_f_array f;


### PR DESCRIPTION
**Summary**

Updates the Hopkins bonded contact model, so that rather than integrating the explicit bond positions in time, they are inferred from the element orientation and an initial bond angle. The concomitant DEMSI branch is https://github.com/akturner/DEMSI/tree/simplified_bonds

**Related Issue(s)**

None

**Author(s)**

Adrian K. Turner (ALNL)

