### PR TITLE
Adding contactType RATE_FORM

### DIFF
--- a/src/KOKKOS/atom_kokkos.cpp
+++ b/src/KOKKOS/atom_kokkos.cpp
@@ -43,7 +43,6 @@ AtomKokkos::~AtomKokkos()
   memoryKK->destroy_kokkos(k_x, x);
   memoryKK->destroy_kokkos(k_v, v);
   memoryKK->destroy_kokkos(k_f, f);
-
   memoryKK->destroy_kokkos(k_mass, mass);
   memoryKK->destroy_kokkos(k_q, q);
 
@@ -91,6 +90,8 @@ AtomKokkos::~AtomKokkos()
   memoryKK->destroy_kokkos(k_coriolis,coriolis);
   memoryKK->destroy_kokkos(k_ocean_vel,ocean_vel);
   memoryKK->destroy_kokkos(k_bvector,bvector);
+
+  memoryKK->destroy_kokkos(k_vn); // adding vn
 
   // SPIN package
   memoryKK->destroy_kokkos(k_sp, sp);

--- a/src/KOKKOS/atom_kokkos.h
+++ b/src/KOKKOS/atom_kokkos.h
@@ -27,7 +27,6 @@ class AtomKokkos : public Atom {
   DAT::tdual_x_array k_x;
   DAT::tdual_v_array k_v;
   DAT::tdual_f_array k_f;
-
   DAT::tdual_float_1d k_mass;
 
   DAT::tdual_float_1d k_q;
@@ -69,7 +68,9 @@ class AtomKokkos : public Atom {
   DAT::tdual_float_2d k_forcing;
   DAT::tdual_float_2d k_ocean_vel;
   DAT::tdual_float_2d k_bvector;
-                       
+
+  DAT::tdual_v_array k_vn; // adding vn
+
   // SPIN package
   DAT::tdual_float_1d_4 k_sp;
   DAT::tdual_f_array k_fm;

--- a/src/KOKKOS/atom_vec_demsi_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_demsi_kokkos.cpp
@@ -132,6 +132,8 @@ void AtomVecDemsiKokkos::grow(int n)
   memoryKK->grow_kokkos(atomKK->k_ocean_vel,atomKK->ocean_vel,nmax,2,"atom:ocean_vel");
   memoryKK->grow_kokkos(atomKK->k_bvector,atomKK->bvector,nmax,2,"atom:bvector");
 
+  memoryKK->grow_kokkos(atomKK->k_vn,atomKK->vn,nmax,"atom:vn"); // adding vn
+
   memoryKK->grow_kokkos(atomKK->k_nspecial,atomKK->nspecial,nmax,3,"atom:nspecial");
   memoryKK->grow_kokkos(atomKK->k_special,atomKK->special,nmax,atom->maxspecial,"atom:special");
 
@@ -237,6 +239,10 @@ void AtomVecDemsiKokkos::grow_pointers()
   d_bvector = atomKK->k_bvector.d_view;
   h_bvector= atomKK->k_bvector.h_view;
 
+  vn = atomKK->vn;
+  d_vn = atomKK->k_vn.d_view; // adding vn
+  h_vn = atomKK->k_vn.h_view;
+
   nspecial = atomKK->nspecial;
   d_nspecial = atomKK->k_nspecial.d_view;
   h_nspecial = atomKK->k_nspecial.h_view;
@@ -306,6 +312,10 @@ void AtomVecDemsiKokkos::copy(int i, int j, int delflag)
   h_ocean_vel(j,1) = h_ocean_vel(i,1);
   h_bvector(j,0) = h_bvector(i,0);
   h_bvector(j,1) = h_bvector(i,1);
+
+  h_vn(j,0) = h_vn(i,0);
+  h_vn(j,1) = h_vn(i,1); // adding vn
+  h_vn(j,2) = h_vn(i,2);
 
   h_nspecial(j,0) = h_nspecial(i,0);
   h_nspecial(j,1) = h_nspecial(i,1);
@@ -1772,6 +1782,7 @@ struct AtomVecDemsiKokkos_PackBorder {
   typename ArrayTypes<DeviceType>::t_float_1d _iceConcentration;
   typename ArrayTypes<DeviceType>::t_float_1d _coriolis;
   typename ArrayTypes<DeviceType>::t_float_2d _ocean_vel,_bvector;
+  typename ArrayTypes<DeviceType>::t_v_array _vn; // adding vn
   X_FLOAT _dx,_dy,_dz;
 
   AtomVecDemsiKokkos_PackBorder(const typename ArrayTypes<DeviceType>::t_xfloat_2d &buf,
@@ -1797,6 +1808,7 @@ struct AtomVecDemsiKokkos_PackBorder {
 			      const typename ArrayTypes<DeviceType>::t_float_1d &coriolis,
 			      const typename ArrayTypes<DeviceType>::t_float_2d &ocean_vel,
 			      const typename ArrayTypes<DeviceType>::t_float_2d &bvector,
+			      const typename ArrayTypes<DeviceType>::t_v_array &vn, // adding vn
 			      const X_FLOAT &dx, const X_FLOAT &dy, const X_FLOAT &dz):
     _buf(buf),
     _list(list),
@@ -1821,6 +1833,7 @@ struct AtomVecDemsiKokkos_PackBorder {
     _coriolis(coriolis),
     _ocean_vel(ocean_vel),
     _bvector(bvector),
+    _vn(vn), // adding vn
     _dx(dx),_dy(dy),_dz(dz) {}
 
   KOKKOS_INLINE_FUNCTION
@@ -1857,6 +1870,9 @@ struct AtomVecDemsiKokkos_PackBorder {
     _buf(i,22) = _ocean_vel(j,1);
     _buf(i,23) = _bvector(j,0);
     _buf(i,24) = _bvector(j,1);
+    _buf(i,25) = _vn(j,0);
+    _buf(i,26) = _vn(j,1); // adding vn
+    _buf(i,26) = _vn(j,2);
   }
 };
 
@@ -1899,6 +1915,7 @@ int AtomVecDemsiKokkos::pack_border_kokkos(int n, DAT::tdual_int_2d k_sendlist, 
         h_coriolis,
         h_ocean_vel,
         h_bvector,
+        h_vn, // adding vn
         dx,dy,dz);
       Kokkos::parallel_for(n,f);
     } else {
@@ -1921,6 +1938,7 @@ int AtomVecDemsiKokkos::pack_border_kokkos(int n, DAT::tdual_int_2d k_sendlist, 
         d_coriolis,
         d_ocean_vel,
         d_bvector,
+        d_vn, // adding vn
         dx,dy,dz);
       Kokkos::parallel_for(n,f);
     }
@@ -1946,6 +1964,7 @@ int AtomVecDemsiKokkos::pack_border_kokkos(int n, DAT::tdual_int_2d k_sendlist, 
         h_coriolis,
         h_ocean_vel,
         h_bvector,
+        h_vn, // adding vn
         dx,dy,dz);
       Kokkos::parallel_for(n,f);
     } else {
@@ -1968,6 +1987,7 @@ int AtomVecDemsiKokkos::pack_border_kokkos(int n, DAT::tdual_int_2d k_sendlist, 
         d_coriolis,
         d_ocean_vel,
         d_bvector,
+        d_vn, // adding vn
         dx,dy,dz);
       Kokkos::parallel_for(n,f);
     }
@@ -2016,6 +2036,9 @@ int AtomVecDemsiKokkos::pack_border(int n, int *list, double *buf,
       buf[m++] = h_ocean_vel(j,1);
       buf[m++] = h_bvector(j,0);
       buf[m++] = h_bvector(j,1);
+      buf[m++] = h_vn(j,0);
+      buf[m++] = h_vn(j,1); // adding vn
+      buf[m++] = h_vn(j,2);
     }
   } else {
     if (domain->triclinic == 0) {
@@ -2054,6 +2077,9 @@ int AtomVecDemsiKokkos::pack_border(int n, int *list, double *buf,
       buf[m++] = h_ocean_vel(j,1);
       buf[m++] = h_bvector(j,0);
       buf[m++] = h_bvector(j,1);
+      buf[m++] = h_vn(j,0);
+      buf[m++] = h_vn(j,1); // adding vn
+      buf[m++] = h_vn(j,2);
     }
   }
 
@@ -2093,6 +2119,7 @@ struct AtomVecDemsiKokkos_PackBorderVel {
   typename ArrayTypes<DeviceType>::t_float_1d _coriolis;
   typename ArrayTypes<DeviceType>::t_float_2d _ocean_vel;
   typename ArrayTypes<DeviceType>::t_float_2d _bvector;
+  typename ArrayTypes<DeviceType>::t_v_array _vn; // adding vn
   typename ArrayTypes<DeviceType>::t_v_array _v;
   typename ArrayTypes<DeviceType>::t_v_array _omega;
   X_FLOAT _dx,_dy,_dz, _dvx, _dvy, _dvz;
@@ -2122,6 +2149,7 @@ struct AtomVecDemsiKokkos_PackBorderVel {
     const typename ArrayTypes<DeviceType>::t_float_1d &coriolis,
     const typename ArrayTypes<DeviceType>::t_float_2d &ocean_vel,
     const typename ArrayTypes<DeviceType>::t_float_2d &bvector,
+    const typename ArrayTypes<DeviceType>::t_v_array &vn, // adding vn
     const typename ArrayTypes<DeviceType>::t_v_array &v,
     const typename ArrayTypes<DeviceType>::t_v_array &omega,
     const X_FLOAT &dx, const X_FLOAT &dy, const X_FLOAT &dz,
@@ -2150,6 +2178,7 @@ struct AtomVecDemsiKokkos_PackBorderVel {
     _coriolis(coriolis),
     _ocean_vel(ocean_vel),
     _bvector(bvector),
+    _vn(vn), // adding vn
     _v(v), _omega(omega),
     _dx(dx),_dy(dy),_dz(dz),
     _dvx(dvx),_dvy(dvy),_dvz(dvz),
@@ -2194,21 +2223,24 @@ struct AtomVecDemsiKokkos_PackBorderVel {
     _buf(i,22) = _ocean_vel(j,1);
     _buf(i,23) = _bvector(j,0);
     _buf(i,24) = _bvector(j,1);
+    _buf(i,25) = _vn(j,0);
+    _buf(i,26) = _vn(j,1); // adding vn
+    _buf(i,27) = _vn(j,2);
     if (DEFORM_VREMAP) {
       if (_mask(i) & _deform_groupbit) {
-        _buf(i,25) = _v(j,0) + _dvx;
-        _buf(i,26) = _v(j,1) + _dvy;
-        _buf(i,27) = _v(j,2) + _dvz;
+        _buf(i,28) = _v(j,0) + _dvx;
+        _buf(i,29) = _v(j,1) + _dvy; // adding vn
+        _buf(i,30) = _v(j,2) + _dvz;
       }
     }
     else {
-      _buf(i,25) = _v(j,0);
-      _buf(i,26) = _v(j,1);
-      _buf(i,27) = _v(j,2);
+      _buf(i,28) = _v(j,0);
+      _buf(i,29) = _v(j,1); // adding vn
+      _buf(i,30) = _v(j,2);
     }
-    _buf(i,28) = _omega(j,0);
-    _buf(i,29) = _omega(j,1);
-    _buf(i,30) = _omega(j,2);
+    _buf(i,31) = _omega(j,0);
+    _buf(i,32) = _omega(j,1); // adding vn
+    _buf(i,33) = _omega(j,2);
   }
 };
 
@@ -2254,6 +2286,7 @@ int AtomVecDemsiKokkos::pack_border_vel_kokkos(
           h_coriolis,
           h_ocean_vel,
           h_bvector,
+          h_vn, // adding vn
           h_v,
           h_omega,
           dx,dy,dz,dvx,dvy,dvz,
@@ -2279,6 +2312,7 @@ int AtomVecDemsiKokkos::pack_border_vel_kokkos(
           d_coriolis,
           d_ocean_vel,
           d_bvector,
+          d_vn, // adding vn
           d_v,
           d_omega,
           dx,dy,dz,dvx,dvy,dvz,
@@ -2310,6 +2344,7 @@ int AtomVecDemsiKokkos::pack_border_vel_kokkos(
           h_coriolis,
           h_ocean_vel,
           h_bvector,
+          h_vn, // adding vn
           h_v,
           h_omega,
           dx,dy,dz,dvx,dvy,dvz,
@@ -2335,6 +2370,7 @@ int AtomVecDemsiKokkos::pack_border_vel_kokkos(
           d_coriolis,
           d_ocean_vel,
           d_bvector,
+          d_vn, // adding vn
           d_v,
           d_omega,
           dx,dy,dz,dvx,dvy,dvz,
@@ -2363,6 +2399,7 @@ int AtomVecDemsiKokkos::pack_border_vel_kokkos(
         h_coriolis,
         h_ocean_vel,
         h_bvector,
+        h_vn, // adding vn
         h_v,
         h_omega,
         dx,dy,dz,dvx,dvy,dvz,
@@ -2388,6 +2425,7 @@ int AtomVecDemsiKokkos::pack_border_vel_kokkos(
         d_coriolis,
         d_ocean_vel,
         d_bvector,
+        d_vn, // adding vn
         d_v,
         d_omega,
         dx,dy,dz,dvx,dvy,dvz,
@@ -2438,6 +2476,9 @@ int AtomVecDemsiKokkos::pack_border_vel(int n, int *list, double *buf,
       buf[m++] = h_ocean_vel(j,1);
       buf[m++] = h_bvector(j,0);
       buf[m++] = h_bvector(j,1);
+      buf[m++] = h_vn(j,0);
+      buf[m++] = h_vn(j,1); // adding vn
+      buf[m++] = h_vn(j,2);
       buf[m++] = h_v(j,0);
       buf[m++] = h_v(j,1);
       buf[m++] = h_v(j,2);
@@ -2483,6 +2524,9 @@ int AtomVecDemsiKokkos::pack_border_vel(int n, int *list, double *buf,
         buf[m++] = h_ocean_vel(j,1);
         buf[m++] = h_bvector(j,0);
         buf[m++] = h_bvector(j,1);
+        buf[m++] = h_vn(j,0);
+        buf[m++] = h_vn(j,1); // adding vn
+        buf[m++] = h_vn(j,2);
         buf[m++] = h_v(j,0);
         buf[m++] = h_v(j,1);
         buf[m++] = h_v(j,2);
@@ -2521,6 +2565,9 @@ int AtomVecDemsiKokkos::pack_border_vel(int n, int *list, double *buf,
         buf[m++] = h_ocean_vel(j,1);
         buf[m++] = h_bvector(j,0);
         buf[m++] = h_bvector(j,1);
+        buf[m++] = h_vn(j,0);
+        buf[m++] = h_vn(j,1); // adding vn
+        buf[m++] = h_vn(j,2);
         if (mask[i] & deform_groupbit) {
           buf[m++] = h_v(j,0) + dvx;
           buf[m++] = h_v(j,1) + dvy;
@@ -2586,6 +2633,7 @@ struct AtomVecDemsiKokkos_UnpackBorder {
   typename ArrayTypes<DeviceType>::t_float_1d _coriolis;
   typename ArrayTypes<DeviceType>::t_float_2d _ocean_vel;
   typename ArrayTypes<DeviceType>::t_float_2d _bvector;
+  typename ArrayTypes<DeviceType>::t_v_array _vn; // adding vn
   int _first;
 
   AtomVecDemsiKokkos_UnpackBorder(
@@ -2610,6 +2658,7 @@ struct AtomVecDemsiKokkos_UnpackBorder {
     typename ArrayTypes<DeviceType>::t_float_1d &coriolis,
     typename ArrayTypes<DeviceType>::t_float_2d &ocean_vel,
     typename ArrayTypes<DeviceType>::t_float_2d &bvector,
+    typename ArrayTypes<DeviceType>::t_v_array &vn, // adding vn
     const int& first):
     _buf(buf),
     _x(x),
@@ -2632,6 +2681,7 @@ struct AtomVecDemsiKokkos_UnpackBorder {
     _coriolis(coriolis),
     _ocean_vel(ocean_vel),
     _bvector(bvector),
+    _vn(vn), // adding vn
     _first(first) {};
 
   KOKKOS_INLINE_FUNCTION
@@ -2661,6 +2711,9 @@ struct AtomVecDemsiKokkos_UnpackBorder {
     _ocean_vel(i+_first,1) = _buf(i,22);
     _bvector(i+_first,0) = _buf(i,23);
     _bvector(i+_first,1) = _buf(i,24);
+    _vn(i+_first,0) = _buf(i,25);
+    _vn(i+_first,1) = _buf(i,26); // adding vn
+    _vn(i+_first,2) = _buf(i,27);
   }
 };
 
@@ -2690,6 +2743,7 @@ void AtomVecDemsiKokkos::unpack_border_kokkos(const int &n, const int &first,
       h_coriolis,
       h_ocean_vel,
       h_bvector,
+      h_vn, // adding vn
       first);
     Kokkos::parallel_for(n,f);
   } else {
@@ -2711,6 +2765,7 @@ void AtomVecDemsiKokkos::unpack_border_kokkos(const int &n, const int &first,
       d_coriolis,
       d_ocean_vel,
       d_bvector,
+      d_vn, // adding vn
       first);
     Kokkos::parallel_for(n,f);
   }
@@ -2753,6 +2808,9 @@ void AtomVecDemsiKokkos::unpack_border(int n, int first, double *buf)
     h_ocean_vel(i,1) = buf[m++];
     h_bvector(i,0) = buf[m++];
     h_bvector(i,1) = buf[m++];
+    h_vn(i,0) = buf[m++];
+    h_vn(i,1) = buf[m++];
+    h_vn(i,2) = buf[m++];
   }
 
   if (atom->nextra_border)
@@ -2791,6 +2849,7 @@ struct AtomVecDemsiKokkos_UnpackBorderVel {
   typename ArrayTypes<DeviceType>::t_float_1d _coriolis;
   typename ArrayTypes<DeviceType>::t_float_2d _ocean_vel;
   typename ArrayTypes<DeviceType>::t_float_2d _bvector;
+  typename ArrayTypes<DeviceType>::t_v_array _vn; // adding vn
   typename ArrayTypes<DeviceType>::t_v_array _v;
   typename ArrayTypes<DeviceType>::t_v_array _omega;
   int _first;
@@ -2817,6 +2876,7 @@ struct AtomVecDemsiKokkos_UnpackBorderVel {
     const typename ArrayTypes<DeviceType>::t_float_1d &coriolis,
     const typename ArrayTypes<DeviceType>::t_float_2d &ocean_vel,
     const typename ArrayTypes<DeviceType>::t_float_2d &bvector,
+    const typename ArrayTypes<DeviceType>::t_v_array &vn, // adding vn
     const typename ArrayTypes<DeviceType>::t_v_array &v,
     const typename ArrayTypes<DeviceType>::t_v_array &omega,
     const int& first):
@@ -2841,6 +2901,7 @@ struct AtomVecDemsiKokkos_UnpackBorderVel {
     _coriolis(coriolis),
     _ocean_vel(ocean_vel),
     _bvector(bvector),
+    _vn(vn), // adding vn
     _v(v),
     _omega(omega),
     _first(first)
@@ -2877,12 +2938,15 @@ struct AtomVecDemsiKokkos_UnpackBorderVel {
     _ocean_vel(i+_first,1) = _buf(i,22);
     _bvector(i+_first,0) = _buf(i,23);
     _bvector(i+_first,1) = _buf(i,24);
-    _v(i+_first,0) = _buf(i,25);
-    _v(i+_first,1) = _buf(i,26);
-    _v(i+_first,2) = _buf(i,27);
-    _omega(i+_first,0) = _buf(i,28);
-    _omega(i+_first,1) = _buf(i,29);
-    _omega(i+_first,2) = _buf(i,30);
+    _vn(i+_first,0) = _buf(i,25);
+    _vn(i+_first,1) = _buf(i,26); // adding vn
+    _vn(i+_first,2) = _buf(i,27);
+    _v(i+_first,0) = _buf(i,28);
+    _v(i+_first,1) = _buf(i,29); // adding vn
+    _v(i+_first,2) = _buf(i,30);
+    _omega(i+_first,0) = _buf(i,31);
+    _omega(i+_first,1) = _buf(i,32); // adding vn
+    _omega(i+_first,2) = _buf(i,33);
   }
 };
 
@@ -2911,6 +2975,7 @@ void AtomVecDemsiKokkos::unpack_border_vel_kokkos(
       h_coriolis,
       h_ocean_vel,
       h_bvector,
+      h_vn, // adding vn
       h_v,
       h_omega,
       first);
@@ -2934,6 +2999,7 @@ void AtomVecDemsiKokkos::unpack_border_vel_kokkos(
       d_coriolis,
       d_ocean_vel,
       d_bvector,
+      d_vn, // adding vn
       d_v,
       d_omega,
       first);
@@ -2978,6 +3044,9 @@ void AtomVecDemsiKokkos::unpack_border_vel(int n, int first, double *buf)
     h_ocean_vel(i,1) = buf[m++];
     h_bvector(i,0) = buf[m++];
     h_bvector(i,1) = buf[m++];
+    h_vn(i,0) = buf[m++];
+    h_vn(i,1) = buf[m++]; // adding vn
+    h_vn(i,2) = buf[m++];
     h_v(i,0) = buf[m++];
     h_v(i,1) = buf[m++];
     h_v(i,2) = buf[m++];
@@ -3041,6 +3110,7 @@ struct AtomVecDemsiKokkos_PackExchangeFunctor {
   typename AT::t_float_1d_randomread _coriolis;
   typename AT::t_float_2d_randomread _ocean_vel;
   typename AT::t_float_2d_randomread _bvector;
+  typename AT::t_v_array_randomread _vn; // adding vn
   typename AT::t_int_1d_randomread _num_bond;
   typename AT::t_int_2d_randomread _bond_type;
   typename AT::t_tagint_2d_randomread _bond_atom;
@@ -3069,6 +3139,7 @@ struct AtomVecDemsiKokkos_PackExchangeFunctor {
   typename AT::t_float_1d _coriolisw;
   typename AT::t_float_2d _ocean_velw;
   typename AT::t_float_2d _bvectorw;
+  typename AT::t_v_array _vnw; // adding vn
   typename AT::t_int_1d _num_bondw;
   typename AT::t_int_2d _bond_typew;
   typename AT::t_tagint_2d _bond_atomw;
@@ -3109,6 +3180,7 @@ struct AtomVecDemsiKokkos_PackExchangeFunctor {
     _coriolis(atom->k_coriolis.view<DeviceType>()),
     _ocean_vel(atom->k_ocean_vel.view<DeviceType>()),
     _bvector(atom->k_bvector.view<DeviceType>()),
+    _vn(atom->k_vn.view<DeviceType>()), // adding vn
     _num_bond(atom->k_num_bond.view<DeviceType>()),
     _bond_type(atom->k_bond_type.view<DeviceType>()),
     _bond_atom(atom->k_bond_atom.view<DeviceType>()),
@@ -3138,6 +3210,7 @@ struct AtomVecDemsiKokkos_PackExchangeFunctor {
     _coriolisw(atom->k_coriolis.view<DeviceType>()),
     _ocean_velw(atom->k_ocean_vel.view<DeviceType>()),
     _bvectorw(atom->k_bvector.view<DeviceType>()),
+    _vnw(atom->k_vn.view<DeviceType>()), // adding vn
     _num_bondw(atom->k_num_bond.view<DeviceType>()),
     _bond_typew(atom->k_bond_type.view<DeviceType>()),
     _bond_atomw(atom->k_bond_atom.view<DeviceType>()),
@@ -3189,6 +3262,9 @@ struct AtomVecDemsiKokkos_PackExchangeFunctor {
     _buf(mysend,m++) = _ocean_vel(i,1);
     _buf(mysend,m++) = _bvector(i,0);
     _buf(mysend,m++) = _bvector(i,1);
+    _buf(mysend,m++) = _vn(i,0);
+    _buf(mysend,m++) = _vn(i,1); // adding vn
+    _buf(mysend,m++) = _vn(i,2);
     _buf(mysend,m++) = d_ubuf(_num_bond(i)).d;
     for (int k = 0; k < _num_bond(i); k++) {
       _buf(mysend,m++) = d_ubuf(_bond_type(i,k)).d;
@@ -3235,6 +3311,9 @@ struct AtomVecDemsiKokkos_PackExchangeFunctor {
       _ocean_velw(i,1) = _ocean_vel(j,1);
       _bvectorw(i,0) = _bvector(j,0);
       _bvectorw(i,1) = _bvector(j,1);
+      _vnw(i,0) = _vn(j,0);
+      _vnw(i,1) = _vn(j,1); // adding vn
+      _vnw(i,2) = _vn(j,2);
       _num_bondw(i) = _num_bond(j);
       for (int k = 0; k < _num_bond(j); k++) {
         _bond_typew(i,k) = _bond_type(j,k);
@@ -3328,7 +3407,10 @@ int AtomVecDemsiKokkos::pack_exchange(int i, double *buf)
   buf[m++] = h_ocean_vel(i,1);
   buf[m++] = h_bvector(i,0);
   buf[m++] = h_bvector(i,1);
-
+  buf[m++] = h_vn(i,0);
+  buf[m++] = h_vn(i,1); // adding vn
+  buf[m++] = h_vn(i,2);
+  
   buf[m++] = ubuf(h_num_bond(i)).d;
   for (int k = 0; k < h_num_bond(i); k++) {
     buf[m++] = ubuf(h_bond_type(i,k)).d;
@@ -3378,6 +3460,7 @@ struct AtomVecDemsiKokkos_UnpackExchangeFunctor {
   typename AT::t_float_1d _coriolis;
   typename AT::t_float_2d _ocean_vel;
   typename AT::t_float_2d _bvector;
+  typename AT::t_v_array _vn; // adding vn
   typename AT::t_int_1d _num_bond;
   typename AT::t_int_2d _bond_type;
   typename AT::t_tagint_2d _bond_atom;
@@ -3418,6 +3501,7 @@ struct AtomVecDemsiKokkos_UnpackExchangeFunctor {
     _coriolis(atom->k_coriolis.view<DeviceType>()),
     _ocean_vel(atom->k_ocean_vel.view<DeviceType>()),
     _bvector(atom->k_bvector.view<DeviceType>()),
+    _vn(atom->k_vn.view<DeviceType>()), // adding vn
     _num_bond(atom->k_num_bond.view<DeviceType>()),
     _bond_type(atom->k_bond_type.view<DeviceType>()),
     _bond_atom(atom->k_bond_atom.view<DeviceType>()),
@@ -3469,6 +3553,9 @@ struct AtomVecDemsiKokkos_UnpackExchangeFunctor {
       _ocean_vel(i,1) = _buf(myrecv,m++);
       _bvector(i,0) = _buf(myrecv,m++);
       _bvector(i,1) = _buf(myrecv,m++);
+      _vn(i,0) = _buf(myrecv,m++);
+      _vn(i,1) = _buf(myrecv,m++); // adding vn
+      _vn(i,2) = _buf(myrecv,m++);
       _num_bond(i) = (int) d_ubuf(_buf(myrecv,m++)).i;
       int k;
       for (k = 0; k < _num_bond(i); k++) {
@@ -3560,6 +3647,9 @@ int AtomVecDemsiKokkos::unpack_exchange(double *buf)
   h_ocean_vel(nlocal,1) = buf[m++];
   h_bvector(nlocal,0) = buf[m++];
   h_bvector(nlocal,1) = buf[m++];
+  h_vn(nlocal,0) = buf[m++];
+  h_vn(nlocal,1) = buf[m++]; // adding vn
+  h_vn(nlocal,2) = buf[m++];
 
   h_num_bond(nlocal) = (int) ubuf(buf[m++]).i;
   for (int k = 0; k < h_num_bond(nlocal); k++) {
@@ -3794,6 +3884,9 @@ void AtomVecDemsiKokkos::create_atom(int itype, double *coord)
   h_ocean_vel(nlocal,1) = 0.0;
   h_bvector(nlocal,0) = 0.0;
   h_bvector(nlocal,1) = 0.0;
+  h_vn(nlocal,0) = 0.0;
+  h_vn(nlocal,1) = 0.0; // adding vn
+  h_vn(nlocal,2) = 0.0;
 
   h_num_bond[nlocal] = 0;
   h_nspecial(nlocal,0) = h_nspecial(nlocal,1) = h_nspecial(nlocal,2) = 0;
@@ -4069,6 +4162,7 @@ double AtomVecDemsiKokkos::memory_usage()
   if (atom->memcheck("coriolis")) bytes += memory->usage(coriolis,nmax);
   if (atom->memcheck("ocean_vel")) bytes += memory->usage(ocean_vel,nmax,2);
   if (atom->memcheck("bvector")) bytes += memory->usage(bvector,nmax,2);
+  if (atom->memcheck("vn")) bytes += memory->usage(vn,nmax,3); // adding vn
 
   if (atom->memcheck("num_bond")) bytes += memory->usage(num_bond,nmax);
   if (atom->memcheck("bond_type"))
@@ -4114,6 +4208,7 @@ void AtomVecDemsiKokkos::sync(ExecutionSpace space, unsigned int mask)
         atomKK->k_coriolis.sync<LMPDeviceType>();
         atomKK->k_ocean_vel.sync<LMPDeviceType>();
         atomKK->k_bvector.sync<LMPDeviceType>();
+        atomKK->k_vn.sync<LMPDeviceType>(); // adding vn
     }
     if (mask & BOND_MASK) {
         atomKK->k_num_bond.sync<LMPDeviceType>();
@@ -4151,6 +4246,7 @@ void AtomVecDemsiKokkos::sync(ExecutionSpace space, unsigned int mask)
         atomKK->k_coriolis.sync<LMPHostType>();
         atomKK->k_ocean_vel.sync<LMPHostType>();
         atomKK->k_bvector.sync<LMPHostType>();
+        atomKK->k_vn.sync<LMPHostType>(); // adding vn
     }
     if (mask & BOND_MASK) {
         atomKK->k_num_bond.sync<LMPHostType>();
@@ -4220,6 +4316,8 @@ void AtomVecDemsiKokkos::sync_overlapping_device(ExecutionSpace space, unsigned 
            perform_async_copy<DAT::tdual_float_2d>(atomKK->k_ocean_vel,space);
         if (atomKK->k_bvector.need_sync<LMPDeviceType>())
            perform_async_copy<DAT::tdual_float_2d>(atomKK->k_bvector,space);
+        if (atomKK->k_vn.need_sync<LMPDeviceType>())
+           perform_async_copy<DAT::tdual_v_array>(atomKK->k_vn,space); // adding vn
     }
     if (mask & SPECIAL_MASK) {
       if (atomKK->k_nspecial.need_sync<LMPDeviceType>())
@@ -4287,6 +4385,8 @@ void AtomVecDemsiKokkos::sync_overlapping_device(ExecutionSpace space, unsigned 
            perform_async_copy<DAT::tdual_float_2d>(atomKK->k_ocean_vel,space);
         if (atomKK->k_bvector.need_sync<LMPHostType>())
            perform_async_copy<DAT::tdual_float_2d>(atomKK->k_bvector,space);
+        if (atomKK->k_vn.need_sync<LMPHostType>())
+           perform_async_copy<DAT::tdual_v_array>(atomKK->k_vn,space); // adding vn
     }
     if (mask & SPECIAL_MASK) {
       if (atomKK->k_nspecial.need_sync<LMPHostType>())
@@ -4336,6 +4436,7 @@ void AtomVecDemsiKokkos::modified(ExecutionSpace space, unsigned int mask)
         atomKK->k_coriolis.modify<LMPDeviceType>();
         atomKK->k_ocean_vel.modify<LMPDeviceType>();
         atomKK->k_bvector.modify<LMPDeviceType>();
+        atomKK->k_vn.modify<LMPDeviceType>(); // adding vn
     }
     if (mask & BOND_MASK) {
         atomKK->k_num_bond.modify<LMPDeviceType>();
@@ -4373,6 +4474,7 @@ void AtomVecDemsiKokkos::modified(ExecutionSpace space, unsigned int mask)
         atomKK->k_coriolis.modify<LMPHostType>();
         atomKK->k_ocean_vel.modify<LMPHostType>();
         atomKK->k_bvector.modify<LMPHostType>();
+        atomKK->k_vn.modify<LMPHostType>(); // adding vn
     }
     if (mask & BOND_MASK) {
         atomKK->k_num_bond.modify<LMPHostType>();

--- a/src/KOKKOS/atom_vec_demsi_kokkos.h
+++ b/src/KOKKOS/atom_vec_demsi_kokkos.h
@@ -138,6 +138,7 @@ class AtomVecDemsiKokkos : public AtomVecKokkos {
   double *coriolis;
   double **ocean_vel;
   double **bvector;
+  double ** vn; // adding vn
   int radvary;
 
   int **nspecial;
@@ -193,6 +194,8 @@ class AtomVecDemsiKokkos : public AtomVecKokkos {
   HAT::t_float_2d h_ocean_vel;
   DAT::t_float_2d d_bvector;
   HAT::t_float_2d h_bvector;
+  DAT::t_v_array d_vn; // adding vn
+  HAT::t_v_array h_vn; // adding vn
 
   DAT::t_int_2d d_nspecial;
   HAT::t_int_2d h_nspecial;

--- a/src/USER-DEMSI/atom_vec_demsi.cpp
+++ b/src/USER-DEMSI/atom_vec_demsi.cpp
@@ -37,8 +37,8 @@ AtomVecDemsi::AtomVecDemsi(LAMMPS *lmp) : AtomVec(lmp)
 
   comm_x_only = 1;
   comm_f_only = 0;
-  size_forward = 3;
-  size_reverse = 6;
+  size_forward = 6; //size_forward = 3; adding vn
+  size_reverse = 9; //size_reverse = 6; adding vn
   size_border = 20;
   size_velocity = 6;
   size_data_atom = 7;
@@ -110,6 +110,8 @@ void AtomVecDemsi::grow(int n)
   ocean_vel = memory->grow(atom->ocean_vel,nmax,2,"atom:ocean_vel");
   bvector = memory->grow(atom->bvector,nmax,2,"atom:bvector");
 
+  vn = memory->grow(atom->vn,nmax,3,"atom:vn"); // adding vn
+
   nspecial = memory->grow(atom->nspecial,nmax,3,"atom:nspecial");
   special = memory->grow(atom->special,nmax,atom->maxspecial,"atom:special");
   num_bond = memory->grow(atom->num_bond,nmax,"atom:num_bond");
@@ -146,6 +148,8 @@ void AtomVecDemsi::grow_reset()
   coriolis = atom->coriolis;
   ocean_vel = atom->ocean_vel;
   bvector = atom->bvector;
+
+  vn = atom->vn; // adding vn
 
   nspecial = atom->nspecial;
   special = atom->special;
@@ -187,6 +191,11 @@ void AtomVecDemsi::copy(int i, int j, int delflag)
   ocean_vel[j][1] = ocean_vel[i][1];
   bvector[j][0] = bvector[i][0];
   bvector[j][1] = bvector[i][1];
+
+  vn[j][0] = vn[i][0];
+  vn[j][1] = vn[i][1]; // adding vn
+  vn[j][2] = vn[i][2];
+
   nspecial[j][0] = nspecial[i][0];
   nspecial[j][1] = nspecial[i][1];
   nspecial[j][2] = nspecial[i][2];
@@ -218,6 +227,11 @@ int AtomVecDemsi::pack_comm(int n, int *list, double *buf,
         buf[m++] = x[j][0];
         buf[m++] = x[j][1];
         buf[m++] = x[j][2];
+        
+        buf[m++] = vn[j][0];
+        buf[m++] = vn[j][1]; // adding vn
+        buf[m++] = vn[j][2];
+        
       }
     } else {
       if (domain->triclinic == 0) {
@@ -234,6 +248,11 @@ int AtomVecDemsi::pack_comm(int n, int *list, double *buf,
         buf[m++] = x[j][0] + dx;
         buf[m++] = x[j][1] + dy;
         buf[m++] = x[j][2] + dz;
+        
+        buf[m++] = vn[j][0];
+        buf[m++] = vn[j][1]; // adding vn
+        buf[m++] = vn[j][2];
+        
       }
     }
 
@@ -245,6 +264,11 @@ int AtomVecDemsi::pack_comm(int n, int *list, double *buf,
         buf[m++] = x[j][0];
         buf[m++] = x[j][1];
         buf[m++] = x[j][2];
+        
+        buf[m++] = vn[j][0];
+        buf[m++] = vn[j][1]; // adding vn
+        buf[m++] = vn[j][2];
+        
         buf[m++] = radius[j];
         buf[m++] = rmass[j];
       }
@@ -263,6 +287,11 @@ int AtomVecDemsi::pack_comm(int n, int *list, double *buf,
         buf[m++] = x[j][0] + dx;
         buf[m++] = x[j][1] + dy;
         buf[m++] = x[j][2] + dz;
+        
+        buf[m++] = vn[j][0];
+        buf[m++] = vn[j][1]; // adding vn
+        buf[m++] = vn[j][2];
+        
         buf[m++] = radius[j];
         buf[m++] = rmass[j];
       }
@@ -288,6 +317,11 @@ int AtomVecDemsi::pack_comm_vel(int n, int *list, double *buf,
         buf[m++] = x[j][0];
         buf[m++] = x[j][1];
         buf[m++] = x[j][2];
+        
+        buf[m++] = vn[j][0];
+        buf[m++] = vn[j][1]; // adding vn
+        buf[m++] = vn[j][2];
+        
         buf[m++] = v[j][0];
         buf[m++] = v[j][1];
         buf[m++] = v[j][2];
@@ -311,6 +345,11 @@ int AtomVecDemsi::pack_comm_vel(int n, int *list, double *buf,
           buf[m++] = x[j][0] + dx;
           buf[m++] = x[j][1] + dy;
           buf[m++] = x[j][2] + dz;
+          
+          buf[m++] = vn[j][0];
+          buf[m++] = vn[j][1]; // adding vn
+          buf[m++] = vn[j][2];
+          
           buf[m++] = v[j][0];
           buf[m++] = v[j][1];
           buf[m++] = v[j][2];
@@ -327,6 +366,11 @@ int AtomVecDemsi::pack_comm_vel(int n, int *list, double *buf,
           buf[m++] = x[j][0] + dx;
           buf[m++] = x[j][1] + dy;
           buf[m++] = x[j][2] + dz;
+            
+            buf[m++] = vn[j][0];
+            buf[m++] = vn[j][1]; // adding vn
+            buf[m++] = vn[j][2];
+            
           if (mask[i] & deform_groupbit) {
             buf[m++] = v[j][0] + dvx;
             buf[m++] = v[j][1] + dvy;
@@ -351,6 +395,11 @@ int AtomVecDemsi::pack_comm_vel(int n, int *list, double *buf,
         buf[m++] = x[j][0];
         buf[m++] = x[j][1];
         buf[m++] = x[j][2];
+        
+        buf[m++] = vn[j][0];
+        buf[m++] = vn[j][1]; // adding vn
+        buf[m++] = vn[j][2];
+        
         buf[m++] = radius[j];
         buf[m++] = rmass[j];
         buf[m++] = v[j][0];
@@ -376,6 +425,11 @@ int AtomVecDemsi::pack_comm_vel(int n, int *list, double *buf,
           buf[m++] = x[j][0] + dx;
           buf[m++] = x[j][1] + dy;
           buf[m++] = x[j][2] + dz;
+          
+          buf[m++] = vn[j][0]; // adding vn
+          buf[m++] = vn[j][1];
+          buf[m++] = vn[j][2];
+          
           buf[m++] = radius[j];
           buf[m++] = rmass[j];
           buf[m++] = v[j][0];
@@ -394,6 +448,11 @@ int AtomVecDemsi::pack_comm_vel(int n, int *list, double *buf,
           buf[m++] = x[j][0] + dx;
           buf[m++] = x[j][1] + dy;
           buf[m++] = x[j][2] + dz;
+          
+          buf[m++] = vn[j][0];
+          buf[m++] = vn[j][1]; // adding vn
+          buf[m++] = vn[j][2];
+          
           buf[m++] = radius[j];
           buf[m++] = rmass[j];
           if (mask[i] & deform_groupbit) {
@@ -446,6 +505,10 @@ void AtomVecDemsi::unpack_comm(int n, int first, double *buf)
       x[i][0] = buf[m++];
       x[i][1] = buf[m++];
       x[i][2] = buf[m++];
+      
+      vn[i][0] = buf[m++];
+      vn[i][1] = buf[m++]; // adding vn
+      vn[i][2] = buf[m++];
     }
   } else {
     m = 0;
@@ -454,6 +517,11 @@ void AtomVecDemsi::unpack_comm(int n, int first, double *buf)
       x[i][0] = buf[m++];
       x[i][1] = buf[m++];
       x[i][2] = buf[m++];
+      
+      vn[i][0] = buf[m++];
+      vn[i][1] = buf[m++]; // adding vn
+      vn[i][2] = buf[m++];
+      
       radius[i] = buf[m++];
       rmass[i] = buf[m++];
     }
@@ -473,9 +541,15 @@ void AtomVecDemsi::unpack_comm_vel(int n, int first, double *buf)
       x[i][0] = buf[m++];
       x[i][1] = buf[m++];
       x[i][2] = buf[m++];
+      
+      vn[i][0] = buf[m++];
+      vn[i][1] = buf[m++]; // adding vn
+      vn[i][2] = buf[m++];
+      
       v[i][0] = buf[m++];
       v[i][1] = buf[m++];
       v[i][2] = buf[m++];
+      
       omega[i][0] = buf[m++];
       omega[i][1] = buf[m++];
       omega[i][2] = buf[m++];
@@ -487,6 +561,11 @@ void AtomVecDemsi::unpack_comm_vel(int n, int first, double *buf)
       x[i][0] = buf[m++];
       x[i][1] = buf[m++];
       x[i][2] = buf[m++];
+      
+      vn[i][0] = buf[m++];
+      vn[i][1] = buf[m++]; // adding vn
+      vn[i][2] = buf[m++];
+      
       radius[i] = buf[m++];
       rmass[i] = buf[m++];
       v[i][0] = buf[m++];
@@ -528,6 +607,11 @@ int AtomVecDemsi::pack_reverse(int n, int first, double *buf)
     buf[m++] = f[i][0];
     buf[m++] = f[i][1];
     buf[m++] = f[i][2];
+    
+    buf[m++] = vn[i][0];
+    buf[m++] = vn[i][1]; // adding vn
+    buf[m++] = vn[i][2];
+    
     buf[m++] = torque[i][0];
     buf[m++] = torque[i][1];
     buf[m++] = torque[i][2];
@@ -563,6 +647,11 @@ void AtomVecDemsi::unpack_reverse(int n, int *list, double *buf)
     f[j][0] += buf[m++];
     f[j][1] += buf[m++];
     f[j][2] += buf[m++];
+    
+    vn[j][0] += buf[m++];
+    vn[j][1] += buf[m++]; // adding vn
+    vn[j][2] += buf[m++];
+    
     torque[j][0] += buf[m++];
     torque[j][1] += buf[m++];
     torque[j][2] += buf[m++];
@@ -600,6 +689,11 @@ int AtomVecDemsi::pack_border(int n, int *list, double *buf,
       buf[m++] = x[j][0];
       buf[m++] = x[j][1];
       buf[m++] = x[j][2];
+
+      buf[m++] = vn[j][0];
+      buf[m++] = vn[j][1]; // adding vn
+      buf[m++] = vn[j][2];
+
       buf[m++] = forcing[j][0];
       buf[m++] = forcing[j][1];
       buf[m++] = mean_thickness[j];
@@ -631,6 +725,11 @@ int AtomVecDemsi::pack_border(int n, int *list, double *buf,
       buf[m++] = x[j][0] + dx;
       buf[m++] = x[j][1] + dy;
       buf[m++] = x[j][2] + dz;
+      
+      buf[m++] = vn[j][0];
+      buf[m++] = vn[j][1]; // adding vn
+      buf[m++] = vn[j][2];
+      
       buf[m++] = forcing[j][0];
       buf[m++] = forcing[j][1];
       buf[m++] = mean_thickness[j];
@@ -671,6 +770,11 @@ int AtomVecDemsi::pack_border_vel(int n, int *list, double *buf,
       buf[m++] = x[j][0];
       buf[m++] = x[j][1];
       buf[m++] = x[j][2];
+
+      buf[m++] = vn[j][0];
+      buf[m++] = vn[j][1]; // adding vn
+      buf[m++] = vn[j][2];
+
       buf[m++] = forcing[j][0];
       buf[m++] = forcing[j][1];
       buf[m++] = mean_thickness[j];
@@ -709,6 +813,11 @@ int AtomVecDemsi::pack_border_vel(int n, int *list, double *buf,
         buf[m++] = x[j][0] + dx;
         buf[m++] = x[j][1] + dy;
         buf[m++] = x[j][2] + dz;
+
+        buf[m++] = vn[j][0];
+        buf[m++] = vn[j][1]; // adding vn
+        buf[m++] = vn[j][2];
+
         buf[m++] = forcing[j][0];
         buf[m++] = forcing[j][1];
         buf[m++] = mean_thickness[j];
@@ -740,6 +849,11 @@ int AtomVecDemsi::pack_border_vel(int n, int *list, double *buf,
         buf[m++] = x[j][0] + dx;
         buf[m++] = x[j][1] + dy;
         buf[m++] = x[j][2] + dz;
+
+        buf[m++] = vn[j][0];
+        buf[m++] = vn[j][1]; // adding vn
+        buf[m++] = vn[j][2];
+
         buf[m++] = forcing[j][0];
         buf[m++] = forcing[j][1];
         buf[m++] = mean_thickness[j];
@@ -806,6 +920,11 @@ void AtomVecDemsi::unpack_border(int n, int first, double *buf)
     x[i][0] = buf[m++];
     x[i][1] = buf[m++];
     x[i][2] = buf[m++];
+
+   vn[i][0] = buf[m++];
+   vn[i][1] = buf[m++]; // adding vn
+   vn[i][2] = buf[m++];
+
     forcing[i][0] = buf[m++];
     forcing[i][1] = buf[m++];
     mean_thickness[i] = buf[m++];
@@ -843,6 +962,11 @@ void AtomVecDemsi::unpack_border_vel(int n, int first, double *buf)
     x[i][0] = buf[m++];
     x[i][1] = buf[m++];
     x[i][2] = buf[m++];
+    
+   vn[i][0] = buf[m++];
+   vn[i][1] = buf[m++]; // adding vn
+   vn[i][2] = buf[m++];
+    
     forcing[i][0] = buf[m++];
     forcing[i][1] = buf[m++];
     mean_thickness[i] = buf[m++];
@@ -898,6 +1022,11 @@ int AtomVecDemsi::pack_exchange(int i, double *buf)
   buf[m++] = x[i][0];
   buf[m++] = x[i][1];
   buf[m++] = x[i][2];
+  
+  buf[m++] = vn[i][0];
+  buf[m++] = vn[i][1]; // adding vn
+  buf[m++] = vn[i][2];
+  
   buf[m++] = forcing[i][0];
   buf[m++] = forcing[i][1];
   buf[m++] = mean_thickness[i];
@@ -908,6 +1037,7 @@ int AtomVecDemsi::pack_exchange(int i, double *buf)
   buf[m++] = ocean_vel[i][1];
   buf[m++] = bvector[i][0];
   buf[m++] = bvector[i][1];
+
   buf[m++] = v[i][0];
   buf[m++] = v[i][1];
   buf[m++] = v[i][2];
@@ -952,16 +1082,22 @@ int AtomVecDemsi::unpack_exchange(double *buf)
   x[nlocal][0] = buf[m++];
   x[nlocal][1] = buf[m++];
   x[nlocal][2] = buf[m++];
-  forcing[nlocal][0] = buf[m++];
-  forcing[nlocal][1] = buf[m++];
-  mean_thickness[nlocal] = buf[m++];
-  min_thickness[nlocal] = buf[m++];
-  ice_area[nlocal] = buf[m++];
-  coriolis[nlocal] = buf[m++];
-  ocean_vel[nlocal][0] = buf[m++];
-  ocean_vel[nlocal][1] = buf[m++];
-  bvector[nlocal][0] = buf[m++];
-  bvector[nlocal][1] = buf[m++];
+  
+  vn[nlocal][0] = buf[m++];
+  vn[nlocal][1] = buf[m++]; // adding vn
+  vn[nlocal][2] = buf[m++];
+  
+forcing[nlocal][0] = buf[m++];
+forcing[nlocal][1] = buf[m++];
+mean_thickness[nlocal] = buf[m++];
+min_thickness[nlocal] = buf[m++];
+ice_area[nlocal] = buf[m++];
+coriolis[nlocal] = buf[m++];
+ocean_vel[nlocal][0] = buf[m++];
+ocean_vel[nlocal][1] = buf[m++];
+bvector[nlocal][0] = buf[m++];
+bvector[nlocal][1] = buf[m++];
+
   v[nlocal][0] = buf[m++];
   v[nlocal][1] = buf[m++];
   v[nlocal][2] = buf[m++];
@@ -976,16 +1112,16 @@ int AtomVecDemsi::unpack_exchange(double *buf)
   omega[nlocal][1] = buf[m++];
   omega[nlocal][2] = buf[m++];
 
-  num_bond[nlocal] = (int) ubuf(buf[m++]).i;
-  for (int k = 0; k < num_bond[nlocal]; k++) {
-    bond_type[nlocal][k] = (int) ubuf(buf[m++]).i;
-    bond_atom[nlocal][k] = (tagint) ubuf(buf[m++]).i;
-  }
-  nspecial[nlocal][0] = (int) ubuf(buf[m++]).i;
-  nspecial[nlocal][1] = (int) ubuf(buf[m++]).i;
-  nspecial[nlocal][2] = (int) ubuf(buf[m++]).i;
-  for (int k = 0; k < nspecial[nlocal][2]; k++)
-    special[nlocal][k] = (tagint) ubuf(buf[m++]).i;
+num_bond[nlocal] = (int) ubuf(buf[m++]).i;
+for (int k = 0; k < num_bond[nlocal]; k++) {
+  bond_type[nlocal][k] = (int) ubuf(buf[m++]).i;
+  bond_atom[nlocal][k] = (tagint) ubuf(buf[m++]).i;
+}
+nspecial[nlocal][0] = (int) ubuf(buf[m++]).i;
+nspecial[nlocal][1] = (int) ubuf(buf[m++]).i;
+nspecial[nlocal][2] = (int) ubuf(buf[m++]).i;
+for (int k = 0; k < nspecial[nlocal][2]; k++)
+  special[nlocal][k] = (tagint) ubuf(buf[m++]).i;
 
   if (atom->nextra_grow)
     for (int iextra = 0; iextra < atom->nextra_grow; iextra++)
@@ -1147,6 +1283,11 @@ void AtomVecDemsi::create_atom(int itype, double *coord)
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
   x[nlocal][2] = coord[2];
+  
+  vn[nlocal][0] = 0.0;
+  vn[nlocal][1] = 0.0; // adding vn
+  vn[nlocal][2] = 0.0;
+
   mask[nlocal] = 1;
   image[nlocal] = ((imageint) IMGMAX << IMG2BITS) |
     ((imageint) IMGMAX << IMGBITS) | IMGMAX;
@@ -1206,7 +1347,11 @@ void AtomVecDemsi::data_atom(double *coord, imageint imagetmp, char **values)
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
   x[nlocal][2] = coord[2];
-
+  
+  vn[nlocal][0] = 0.0;
+  vn[nlocal][1] = 0.0; // adding vn
+  vn[nlocal][2] = 0.0;
+  
   image[nlocal] = imagetmp;
 
   mask[nlocal] = 1;
@@ -1411,7 +1556,9 @@ double AtomVecDemsi::memory_usage()
   if (atom->memcheck("x")) bytes += memory->usage(x,nmax,3);
   if (atom->memcheck("v")) bytes += memory->usage(v,nmax,3);
   if (atom->memcheck("f")) bytes += memory->usage(f,nmax*comm->nthreads,3);
-
+  
+  if (atom->memcheck("vn")) bytes += memory->usage(vn,nmax,3); // adding vn
+  
   if (atom->memcheck("radius")) bytes += memory->usage(radius,nmax);
   if (atom->memcheck("rmass")) bytes += memory->usage(rmass,nmax);
   if (atom->memcheck("omega")) bytes += memory->usage(omega,nmax,3);

--- a/src/USER-DEMSI/atom_vec_demsi.h
+++ b/src/USER-DEMSI/atom_vec_demsi.h
@@ -89,6 +89,7 @@ class AtomVecDemsi : public AtomVec {
   double *coriolis;
   double **ocean_vel;
   double **bvector;
+  double **vn; // adding vn
   int radvary;
   int **nspecial;
   tagint **special;

--- a/src/USER-DEMSI/fix_nve_sphere_demsi.cpp
+++ b/src/USER-DEMSI/fix_nve_sphere_demsi.cpp
@@ -114,7 +114,10 @@ void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
         vn[i][0] = v[i][0];
         vn[i][1] = v[i][1];
         vn[i][2] = omega[i][2];
-      
+
+        x[i][0] += dtv * v[i][0];
+        x[i][1] += dtv * v[i][1];
+
         vel_diff = sqrt((ocean_vel[i][0]-v[i][0])*(ocean_vel[i][0]-v[i][0]) +
           (ocean_vel[i][1]-v[i][1])*(ocean_vel[i][1]-v[i][1]));
         D = ice_area[i]*ocean_drag*ocean_density*vel_diff;
@@ -129,9 +132,6 @@ void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
         detinv = 1.0/(a00*a11 - a01*a10);
         v[i][0] = detinv*( a11*b0 - a01*b1);
         v[i][1] = detinv*(-a10*b0 + a00*b1);
-
-        x[i][0] += dtv * v[i][0];
-        x[i][1] += dtv * v[i][1];
 
         dtirotate = dtf/(0.5*radius[i]*radius[i]*rmass[i]);
         omega[i][2] += dtirotate * torque[i][2];
@@ -152,6 +152,8 @@ void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
 
         x[i][0] += dtf * v[i][0]; // half step
         x[i][1] += dtf * v[i][1];
+//      x[i][0] += dtv * v[i][0]; // full step
+//      x[i][1] += dtv * v[i][1];
 
         vel_diff = sqrt((ocean_vel[i][0]-v[i][0])*(ocean_vel[i][0]-v[i][0]) +
           (ocean_vel[i][1]-v[i][1])*(ocean_vel[i][1]-v[i][1]));

--- a/src/USER-DEMSI/fix_nve_sphere_demsi.cpp
+++ b/src/USER-DEMSI/fix_nve_sphere_demsi.cpp
@@ -47,6 +47,8 @@ FixNVESphereDemsi::FixNVESphereDemsi(LAMMPS *lmp, int narg, char **arg) :
 
   ocean_density = ocean_drag = 0;
 
+  timeIntegrationFlag = 0;
+
   if (domain->dimension != 2)
     error->all(FLERR,"Fix nve/sphere demsi requires 2d simulation");
   if (!atom->demsi_flag)
@@ -90,6 +92,7 @@ void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
   double **ocean_vel = atom->ocean_vel;
   double **bvector = atom->bvector;
   double **forcing = atom->forcing;
+  double **vn = atom->vn; // adding vn
 
   double D, vel_diff, m_prime;
   double a00, a01, a10, a11;
@@ -103,44 +106,93 @@ void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
 
   // set timestep here since dt may have changed or come via rRESPA
 
+  double dtv = update->dt;
+  double dtf = 0.5 * update->dt;
+  
   double dtfrotate = dtf / inertia;
   double dtirotate;
   // update v,x,omega for all particles
   // d_omega/dt = torque / inertia
 
-  for (int i = 0; i < nlocal; i++) {
-    if (mask[i] & groupbit) {
-      vel_diff = sqrt((ocean_vel[i][0]-v[i][0])*(ocean_vel[i][0]-v[i][0]) +
+  if (timeIntegrationFlag == 0) { // Hopkins-Verlet form
+
+    for (int i = 0; i < nlocal; i++) {
+      if (mask[i] & groupbit) {
+      
+        vn[i][0] = v[i][0];
+        vn[i][1] = v[i][1];
+        vn[i][2] = omega[i][2];
+      
+        vel_diff = sqrt((ocean_vel[i][0]-v[i][0])*(ocean_vel[i][0]-v[i][0]) +
           (ocean_vel[i][1]-v[i][1])*(ocean_vel[i][1]-v[i][1]));
-      D = ice_area[i]*ocean_drag*ocean_density*vel_diff;
-      m_prime = rmass[i]/dtf;
-      a00 = a11 = m_prime+D;
-      a10 = rmass[i]*coriolis[i];
-      a01 = -a10;
+        D = ice_area[i]*ocean_drag*ocean_density*vel_diff;
+        m_prime = rmass[i]/dtf;
+        a00 = a11 = m_prime+D;
+        a10 = rmass[i]*coriolis[i];
+        a01 = -a10;
 
-      b0 = m_prime*v[i][0] + f[i][0] + bvector[i][0] + forcing[i][0] + D*ocean_vel[i][0];
-      b1 = m_prime*v[i][1] + f[i][1] + bvector[i][1] + forcing[i][1] + D*ocean_vel[i][1];
+        b0 = m_prime*v[i][0] + f[i][0] + bvector[i][0] + forcing[i][0] + D*ocean_vel[i][0];
+        b1 = m_prime*v[i][1] + f[i][1] + bvector[i][1] + forcing[i][1] + D*ocean_vel[i][1];
 
-      detinv = 1.0/(a00*a11 - a01*a10);
-      v[i][0] = detinv*( a11*b0 - a01*b1);
-      v[i][1] = detinv*(-a10*b0 + a00*b1);
+        detinv = 1.0/(a00*a11 - a01*a10);
+        v[i][0] = detinv*( a11*b0 - a01*b1);
+        v[i][1] = detinv*(-a10*b0 + a00*b1);
 
-      x[i][0] += dtv * v[i][0];
-      x[i][1] += dtv * v[i][1];
+        x[i][0] += dtv * v[i][0];
+        x[i][1] += dtv * v[i][1];
 
-      dtirotate = dtfrotate / (radius[i]*radius[i]*rmass[i]);
-      omega[i][2] += dtirotate * torque[i][2];
+//      dtirotate = dtfrotate / (radius[i]*radius[i]*rmass[i]);
+        dtirotate = dtf/(inertia*radius[i]*radius[i]*rmass[i]);
+        omega[i][2] += dtirotate * torque[i][2];
 
-    }
-  }
-}
+      } // end if (mask[i] & groupbit)
+    } // end for (int i = 0; i < nlocal; i++)
+    
+  } else { // rate form
+    
+    // load {v,omega} with the explicit accelerations (v^n + dtv*F/M)
+    
+    for (int i = 0; i < nlocal; i++) {
+      if (mask[i] & groupbit) {
+
+        vn[i][0] = v[i][0];
+        vn[i][1] = v[i][1];
+        vn[i][2] = omega[i][2];
+
+        x[i][0] += dtf * v[i][0]; // half step
+        x[i][1] += dtf * v[i][1];
+
+        vel_diff = sqrt((ocean_vel[i][0]-v[i][0])*(ocean_vel[i][0]-v[i][0]) +
+          (ocean_vel[i][1]-v[i][1])*(ocean_vel[i][1]-v[i][1]));
+        D = ice_area[i]*ocean_drag*ocean_density*vel_diff;
+//      m_prime = rmass[i]/dtf;
+        m_prime = rmass[i]/dtv;
+        a00 = a11 = m_prime+D;
+        a10 = rmass[i]*coriolis[i];
+        a01 = -a10;
+
+        b0 = m_prime*v[i][0] + f[i][0] + bvector[i][0] + forcing[i][0] + D*ocean_vel[i][0];
+        b1 = m_prime*v[i][1] + f[i][1] + bvector[i][1] + forcing[i][1] + D*ocean_vel[i][1];
+
+        detinv = 1.0/(a00*a11 - a01*a10);
+        v[i][0] = detinv*( a11*b0 - a01*b1);
+        v[i][1] = detinv*(-a10*b0 + a00*b1);
+
+//      dtirotate = dtf/(inertia*radius[i]*radius[i]*rmass[i]);
+        dtirotate = dtv/(inertia*radius[i]*radius[i]*rmass[i]);
+        omega[i][2] += dtirotate * torque[i][2];
+        
+      } // end if (mask[i] & groupbit)
+    } // end for (int i = 0; i < nlocal; i++)
+  
+  } // end if (timeIntegrationFlag == 0)
+} // end void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
 
 /* ---------------------------------------------------------------------- */
 
 void FixNVESphereDemsi::final_integrate()
 {
-  double dtfm,dtirotate;
-
+  double **x = atom->x;
   double **v = atom->v;
   double **f = atom->f;
   double **omega = atom->omega;
@@ -151,6 +203,7 @@ void FixNVESphereDemsi::final_integrate()
   double **ocean_vel = atom->ocean_vel;
   double **bvector = atom->bvector;
   double **forcing = atom->forcing;
+  double **vn = atom->vn; // adding vn
 
   double *radius = atom->radius;
   int *mask = atom->mask;
@@ -165,14 +218,19 @@ void FixNVESphereDemsi::final_integrate()
 
   // set timestep here since dt may have changed or come via rRESPA
 
+  double dtv = update->dt;
+  double dtf = 0.5 * update->dt;
+  double dtirotate;
   double dtfrotate = dtf / inertia;
 
   // update v,omega for all particles
   // d_omega/dt = torque / inertia
 
-  double rke = 0.0;
-  for (int i = 0; i < nlocal; i++)
-    if (mask[i] & groupbit) {
+  if (timeIntegrationFlag == 0) { // Hopkins-Verlet form
+  
+    double rke = 0.0;
+    for (int i = 0; i < nlocal; i++){
+      if (mask[i] & groupbit) {
       vel_diff = sqrt((ocean_vel[i][0]-v[i][0])*(ocean_vel[i][0]-v[i][0]) +
           (ocean_vel[i][1]-v[i][1])*(ocean_vel[i][1]-v[i][1]));
       D = ice_area[i]*ocean_drag*ocean_density*vel_diff;
@@ -188,10 +246,33 @@ void FixNVESphereDemsi::final_integrate()
       v[i][0] = detinv*( a11*b0 - a01*b1);
       v[i][1] = detinv*(-a10*b0 + a00*b1);
 
-      dtirotate = dtfrotate / (radius[i]*radius[i]*rmass[i]);
+      dtirotate = dtf/(inertia*radius[i]*radius[i]*rmass[i]);
       omega[i][2] += dtirotate * torque[i][2];
+
       rke += (omega[i][0]*omega[i][0] + omega[i][1]*omega[i][1] +
               omega[i][2]*omega[i][2])*radius[i]*radius[i]*rmass[i];
-    }
+      } // end if (mask[i] & groupbit)
+    } // end for (int i = 0; i < nlocal; i++) 
+ 
+  } else { // rate form
+  
+    // v^{n+1}[0,1] is in vn[0,1], omega^{n+1} is in vn[2]
+ 
+    double rke = 0.0;
+    for (int i = 0; i < nlocal; i++){
+      if (mask[i] & groupbit) {
 
-}
+        v[i][0] = vn[i][0];
+        v[i][1] = vn[i][1];
+        omega[i][2] = vn[i][2];
+
+        x[i][0] += dtf * v[i][0]; // half step
+        x[i][1] += dtf * v[i][1];
+      
+      rke += (omega[i][0]*omega[i][0] + omega[i][1]*omega[i][1] +
+              omega[i][2]*omega[i][2])*radius[i]*radius[i]*rmass[i];
+      } // end  if (mask[i] & groupbit)
+    } // end for (int i = 0; i < nlocal; i++)
+  } // end if (timeIntegrationFlag == 0)
+} // end void FixNVESphereDemsi::final_integrate()
+

--- a/src/USER-DEMSI/fix_nve_sphere_demsi.cpp
+++ b/src/USER-DEMSI/fix_nve_sphere_demsi.cpp
@@ -42,8 +42,6 @@ FixNVESphereDemsi::FixNVESphereDemsi(LAMMPS *lmp, int narg, char **arg) :
   time_integrate = 1;
 
   // process extra keywords
-  // inertia = moment of inertia prefactor for sphere or disc
-  inertia = 0.5;
 
   ocean_density = ocean_drag = 0;
 
@@ -78,8 +76,6 @@ void FixNVESphereDemsi::init()
 
 void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
 {
-  double dtfm;
-
   double **x = atom->x;
   double **v = atom->v;
   double **f = atom->f;
@@ -108,11 +104,7 @@ void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
 
   double dtv = update->dt;
   double dtf = 0.5 * update->dt;
-  
-  double dtfrotate = dtf / inertia;
   double dtirotate;
-  // update v,x,omega for all particles
-  // d_omega/dt = torque / inertia
 
   if (timeIntegrationFlag == 0) { // Hopkins-Verlet form
 
@@ -141,8 +133,7 @@ void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
         x[i][0] += dtv * v[i][0];
         x[i][1] += dtv * v[i][1];
 
-//      dtirotate = dtfrotate / (radius[i]*radius[i]*rmass[i]);
-        dtirotate = dtf/(inertia*radius[i]*radius[i]*rmass[i]);
+        dtirotate = dtf/(0.5*radius[i]*radius[i]*rmass[i]);
         omega[i][2] += dtirotate * torque[i][2];
 
       } // end if (mask[i] & groupbit)
@@ -178,8 +169,7 @@ void FixNVESphereDemsi::initial_integrate(int /*vflag*/)
         v[i][0] = detinv*( a11*b0 - a01*b1);
         v[i][1] = detinv*(-a10*b0 + a00*b1);
 
-//      dtirotate = dtf/(inertia*radius[i]*radius[i]*rmass[i]);
-        dtirotate = dtv/(inertia*radius[i]*radius[i]*rmass[i]);
+        dtirotate = dtv/(0.5*radius[i]*radius[i]*rmass[i]);
         omega[i][2] += dtirotate * torque[i][2];
         
       } // end if (mask[i] & groupbit)
@@ -221,10 +211,6 @@ void FixNVESphereDemsi::final_integrate()
   double dtv = update->dt;
   double dtf = 0.5 * update->dt;
   double dtirotate;
-  double dtfrotate = dtf / inertia;
-
-  // update v,omega for all particles
-  // d_omega/dt = torque / inertia
 
   if (timeIntegrationFlag == 0) { // Hopkins-Verlet form
   
@@ -246,7 +232,7 @@ void FixNVESphereDemsi::final_integrate()
       v[i][0] = detinv*( a11*b0 - a01*b1);
       v[i][1] = detinv*(-a10*b0 + a00*b1);
 
-      dtirotate = dtf/(inertia*radius[i]*radius[i]*rmass[i]);
+      dtirotate = dtf/(0.5*radius[i]*radius[i]*rmass[i]);
       omega[i][2] += dtirotate * torque[i][2];
 
       rke += (omega[i][0]*omega[i][0] + omega[i][1]*omega[i][1] +

--- a/src/USER-DEMSI/fix_nve_sphere_demsi.h
+++ b/src/USER-DEMSI/fix_nve_sphere_demsi.h
@@ -36,6 +36,9 @@ class FixNVESphereDemsi : public FixNVE {
   // if they are location/temperature dependent, they would have
   // to be made into per-particle properties)
   double ocean_drag, ocean_density;
+  
+  // control flag, sent to fix_integrator in demsi_external_force.cpp
+  int timeIntegrationFlag;
 
  protected:
   double inertia;

--- a/src/USER-DEMSI/pair_gran_rate.cpp
+++ b/src/USER-DEMSI/pair_gran_rate.cpp
@@ -1,0 +1,980 @@
+/* ----------------------------------------------------------------------
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+   ------------------------------------------------------------------------- */
+
+/* -------------------------------------------------------------------------
+   Contributing authors: Dan S. Bolintineanu (SNL), Adrian K. Turner (LANL),
+   B. A. Kashiwa (LASL)
+   ------------------------------------------------------------------------- */
+
+#include <math.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "pair_gran_rate.h"
+#include "atom.h"
+#include "atom_vec.h"
+#include "update.h"
+#include "force.h"
+#include "fix.h"
+#include "fix_neigh_history.h"
+#include "neighbor.h"
+#include "neigh_list.h"
+#include "comm.h"
+#include "memory.h"
+#include "error.h"
+#include "math_const.h"
+
+#include "group.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+#define DEBUGID_1 35
+#define DEBUGID_2 55
+#define DEBUG_TIMESTEP 32696
+/* ---------------------------------------------------------------------- */
+
+PairGranRate::PairGranRate(LAMMPS *lmp) :
+              PairGranHookeHistory(lmp, 12)
+{
+  nondefault_history_transfer = 1;
+  beyond_contact = 1;
+  
+/*
+  Allocate memory for the block data according to this block scheme:
+  Each element [i] has a block of size N+1 where N is the number of neighbors
+  that are "in contact" with [i] as defined by the touching algorithm below.
+  The list of contacting neighbors is ls[i][j=0,N] so that ls[i][0]=i, and the
+  remaining ls[i][j=1,N] contains the list of up to 6 neighbors, in whatever
+  order they may have been found by the touching algorithm.
+
+  There can be at most 6 contacting neighbors so the maximum block size
+  is 7.  The array vs[i][j][3] contains the velocity {vx,vy,vz} where the
+  azimuthal rotation rate is stored in vz, so the tangential velocity due to
+  rotation is radius[j]*vz.
+  
+  (We use the "auto X = new type[inum]" syntax to create the arrays, and
+  assume that the 'delete' that is requited by 'new' is handled automatically.)
+*/
+/*
+  int inum;
+  inum = list->inum;
+  auto ns = new int[inum]; // number of neighbors "in contact" with [i]
+  auto ls = new int[inum][6]; // list of [j] in the [i] block
+  auto vs = new double[inum][6][3]; // [i][j] block velocity
+*/
+}
+
+/* ---------------------------------------------------------------------- */
+PairGranRate::~PairGranRate()
+{
+/*
+  int inum;
+  inum = list->inum;
+  int ns[inum];
+  int ls[inum][6];
+  double vs[inum][6][3];
+  
+//delete [] ns;  // compiler issues a 'warning deleting ns'
+//delete [] ls;  // and the code segfaults
+//delete [] vs;  // so these must be unnecessary (?)
+*/
+}
+/* ---------------------------------------------------------------------- */
+
+void PairGranRate::compute(int eflag, int vflag)
+{
+  if (eflag || vflag) ev_setup(eflag,vflag);
+  else evflag = vflag_fdotr = 0;
+
+/*
+  // update rigid body info for owned & ghost atoms if using FixRigid masses
+  // body[i] = which body atom I is in, -1 if none
+  // mass_body = mass of each rigid body
+  // Not yet applicable for DEMSI, but may be something to look into
+
+  if (fix_rigid && neighbor->ago == 0){
+    int i;
+    int tmp;
+    int *body = (int *) fix_rigid->extract("body",tmp);
+    double *mass_body = (double *) fix_rigid->extract("masstotal",tmp);
+    if (atom->nmax > nmax) {
+      memory->destroy(mass_rigid);
+      nmax = atom->nmax;
+      memory->create(mass_rigid,nmax,"pair:mass_rigid");
+    }
+    int nlocal = atom->nlocal;
+    for (i = 0; i < nlocal; i++)
+      if (body[i] >= 0) mass_rigid[i] = mass_body[body[i]];
+      else mass_rigid[i] = 0.0;
+    comm->forward_comm_pair(this);
+  }
+*/
+
+  if (int(timeIntegrationFlag) = 0) {
+    compute_rate_exverlet();
+  } else if(int(timeIntegrationFlag) = 1) {
+    compute_rate_explicit(); back_substitute();
+  } else if(int(timeIntegrationFlag) = 2) {
+    compute_rate_implicit(); back_substitute();
+  } else {
+    error->all(FLERR,"int(timeIntegrationFlag) must be (0,1,2)");
+  }
+  
+  if (vflag_fdotr) virial_fdotr_compute();
+
+} // end PairGranRate::compute
+/* ---------------------------------------------------------------------- */
+
+void PairGranRate::compute_rate_exverlet()
+{
+  int i,j,ii,jj,inum,jnum;
+  int itype,jtype;
+
+  int *ilist,*jlist,*numneigh,**firstneigh;
+  int **firsttouch;
+  double *history,*allhistory,**firsthistory;
+  
+  inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  firsttouch = fix_history->firstflag;
+  firsthistory = fix_history->firstvalue;
+  
+  double **x = atom->x;
+  double **v = atom->v;
+  double **f = atom->f;
+  double **vn = atom->vn;
+  double **omega = atom->omega;
+  double **torque = atom->torque;
+  double *radius = atom->radius;
+  double *rmass = atom->rmass;
+  int *type = atom->type;
+  int *mask = atom->mask;
+  int nlocal = atom->nlocal;
+
+//if (igroup == atom->firstgroup) nlocal = atom->nfirst;
+
+  int bondFlagIn; // incoming bondFlag
+  int Fplus;      // outgoing bondFlag
+
+  double delx, dely, rsq, radsum;
+  double radi, radj, r, rinv, nx, ny;
+  double vrx, vry, vnnr, vtx, vty, wrz, vtrx, vtry;
+  double hAVGi, hAVGj, hDeltal;
+  double fx, fy, fz;
+  double Pplus, Sxplus, Syplus; // outgoing Pressure, ShearStresses
+  double SYield;  // shear yield conditions
+
+  int historyupdate = 1;
+  if (update->setupflag) historyupdate = 0;
+
+  double dtv = update->dt;
+  double dtf = 0.5 * update->dt; // * force->ftm2v;
+
+  /* Load the explicit force/torque */
+  
+  for (ii = 0; ii < inum; ii++) {
+    i = ilist[ii];
+    f[i][0] = 0.0;
+    f[i][1] = 0.0;
+    torque[i][2] = 0.0;
+  }
+  
+  for (ii = 0; ii < inum; ii++) {
+    i = ilist[ii];
+    itype = atom->type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+    allhistory = firsthistory[i];
+    radi = radius[i];
+
+    // loop over neighbors of each element
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      jtype = atom->type[j];
+      j &= NEIGHMASK;
+      radj = radius[j];
+
+//    *touch = &firsttouch[i][jj];
+      history = &allhistory[size_history*jj];
+
+      /*'history' now points to the ii-jj array that stores
+         all the history associated with pair ii-jj
+         For all pairs:
+         *history[0]: bondPressure
+         *history[1]: bondShearX
+         *history[2]: bondShearY
+         *history[3]: bondFlag [0=no bond, 1=bonded]]
+      */
+
+//    delx = x[i][0] - x[j][0]; // hooke form uses inward normal relative to [i]
+//    dely = x[i][1] - x[j][1];
+      delx = x[j][0] - x[i][0]; // rate form uses outward normal relative to [i]
+      dely = x[j][1] - x[i][1];
+      rsq = delx*delx + dely*dely;
+//    radsum = OverLap*(radius[i] + radius[j]);
+      radsum = 1.01*(radi + radj);
+
+      bondFlagIn = int(history[3]);
+      Fplus = bondFlagIn;
+
+      if(!bondFlagIn){
+        if (rsq >= radsum*radsum){ // no contact
+          firsttouch[i][jj] = 0;
+          Fplus = 0;
+          Pplus = 0.;
+          Sxplus = 0.;
+          Syplus = 0.;
+          fx = fy = fz = 0.;
+        } else { // in first contact
+          firsttouch[i][jj] = 1;
+          Fplus = 1;
+        } // end if(rsq >= radsum*radsum
+        history[0] = history[1] = history[2] = 0.;
+      } // end if(!bondFlagIn)
+
+      if (Fplus){
+        r = sqrt(rsq);
+        rinv = 1.0/r;
+        nx = delx*rinv;
+        ny = dely*rinv;
+
+        // relative translational velocity
+
+        vrx = v[j][0] - v[i][0];
+        vry = v[j][1] - v[i][1];
+
+        // normal component of the relative translational velocity
+
+        vnnr = vrx*nx + vry*ny;
+
+        // tangential component of the relative translational velocity
+
+        vtx = vrx - vnnr*nx;
+        vty = vry - vnnr*ny;
+
+        // relative rotational velocity
+
+        wrz = (radi*omega[i][2] + radj*omega[j][2]);
+
+        // relative tangential velocity
+
+        vtrx = vtx - ny*wrz;
+        vtry = vty + nx*wrz;
+
+        Pplus  = history[0] - bulkModulus*dtv*vnnr*rinv;
+        Sxplus = history[1] -shearModulus*dtv*vtrx*rinv;
+        Syplus = history[2] -shearModulus*dtv*vtry*rinv;
+
+        hAVGi = rmass[i]/(rho0*MY_PI*radi*radi);
+        hAVGj = rmass[j]/(rho0*MY_PI*radj*radj);
+
+        hDeltal = 2*MY_PI3*(hAVGi*radi * hAVGj*radj)
+                          /(hAVGi*radi + hAVGj*radj);
+
+        fx = (Pplus*nx + Sxplus)*hDeltal;
+        fy = (Pplus*ny + Syplus)*hDeltal;
+        fz = (Sxplus*ny - Syplus*nx)*hDeltal;
+        
+        f[i][0] -= fx;
+        f[i][1] -= fy;
+        torque[i][2] -= radi*fz;
+
+        if (force->newton_pair || j < atom->nlocal){
+          f[j][0] += fx;
+          f[j][1] += fy;
+          torque[j][2] -= radj*fz;
+        }
+
+          // test for tensile fracture, compressive flowstress, shear flowstress
+
+          if (Pplus <= tensileFractureStress) { // tensile fracture
+            Pplus = 0.;
+            Fplus = 0;
+          } else if (Pplus > compressiveYieldStress) { // perfectly plastic compressive flowstress
+            Pplus = compressiveYieldStress;
+          }
+          SYield = sqrt(Sxplus*Sxplus + Syplus*Syplus)/shearYieldStress;
+          if (SYield > 1.0) {
+//          Sxplus /= SYield;
+//          Syplus /= SYield;
+            Sxplus = Syplus = 0.;
+          }
+
+          // update history
+          if(historyupdate){
+            history[0] = Pplus;
+            history[1] = Sxplus;
+            history[2] = Syplus;
+            history[3] = double(Fplus);
+          }
+
+      } // end if (Fplus)
+
+      if (evflag) ev_tally_xyz(i,j,atom->nlocal, force->newton_pair,
+              0.0,0.0,fx,fy,0,x[i][0]-x[j][0],x[i][1]-x[j][1],0);
+              
+
+    } // end for (jj = 0; jj < jnum; jj++)
+  } // end for (ii = 0; ii < inum; ii++)
+} // end PairGranRate::compute_rate_verlet
+/* ---------------------------------------------------------------------- */
+
+void PairGranRate::compute_rate_explicit()
+{
+  int i,j,ii,jj,inum,jnum;
+  int itype,jtype;
+
+  int *ilist,*jlist,*numneigh,**firstneigh;
+  int **firsttouch;
+  double *history,*allhistory,**firsthistory;
+  
+  inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  firsttouch = fix_history->firstflag;
+  firsthistory = fix_history->firstvalue;
+  
+  double **x = atom->x;
+  double **v = atom->v;
+  double **f = atom->f;
+  double **vn = atom->vn;
+  double **omega = atom->omega;
+  double **torque = atom->torque;
+  double *radius = atom->radius;
+  double *rmass = atom->rmass;
+  int *type = atom->type;
+  int *mask = atom->mask;
+  int nlocal = atom->nlocal;
+
+//if (igroup == atom->firstgroup) nlocal = atom->nfirst;
+
+  int bondFlagIn; // incoming bondFlag
+  int Fplus;      // outgoing bondFlag
+
+  double delx, dely, rsq, radsum;
+  double radi, radj, r, rinv, nx, ny;
+  double vrx, vry, vnnr, vtx, vty, wrz, vtrx, vtry;
+  double hAVGi, hAVGj, hDeltal;
+  double fx, fy, fz;
+  double Pplus, Sxplus, Syplus; // outgoing Pressure, ShearStresses
+  double SYield;  // shear yield conditions
+
+  int historyupdate = 1;
+  if (update->setupflag) historyupdate = 0;
+
+  double dtv = update->dt;
+  double dtf = 0.5 * update->dt; // * force->ftm2v;
+
+  /* Load the explicit force/torque */
+  
+  for (ii = 0; ii < inum; ii++) {
+    i = ilist[ii];
+    f[i][0] = 0.0;
+    f[i][1] = 0.0;
+    torque[i][2] = 0.0;
+  }
+  
+  for (ii = 0; ii < inum; ii++) {
+    i = ilist[ii];
+    itype = atom->type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+    allhistory = firsthistory[i];
+    radi = radius[i];
+
+    // loop over neighbors of each element
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      jtype = atom->type[j];
+      j &= NEIGHMASK;
+      radj = radius[j];
+
+//    *touch = &firsttouch[i][jj];
+      history = &allhistory[size_history*jj];
+
+      /*'history' now points to the ii-jj array that stores
+         all the history associated with pair ii-jj
+         For all pairs:
+         *history[0]: bondPressure
+         *history[1]: bondShearX
+         *history[2]: bondShearY
+         *history[3]: bondFlag [0=no bond, 1=bonded]]
+      */
+
+//    delx = x[i][0] - x[j][0]; // hooke form uses inward normal relative to [i]
+//    dely = x[i][1] - x[j][1];
+      delx = x[j][0] - x[i][0]; // rate form uses outward normal relative to [i]
+      dely = x[j][1] - x[i][1];
+      rsq = delx*delx + dely*dely;
+//    radsum = OverLap*(radius[i] + radius[j]);
+      radsum = 1.01*(radi + radj);
+
+      bondFlagIn = int(history[3]);
+      Fplus = bondFlagIn;
+
+      if(!bondFlagIn){
+        if (rsq >= radsum*radsum){ // no contact
+          firsttouch[i][jj] = 0;
+          Fplus = 0;
+          Pplus = 0.;
+          Sxplus = 0.;
+          Syplus = 0.;
+          fx = fy = fz = 0.;
+        } else { // in first contact
+          firsttouch[i][jj] = 1;
+          Fplus = 1;
+        } // end if(rsq >= radsum*radsum
+        history[0] = history[1] = history[2] = 0.;
+      } // end if(!bondFlagIn)
+
+      if (Fplus){
+        r = sqrt(rsq);
+        rinv = 1.0/r;
+        nx = delx*rinv;
+        ny = dely*rinv;
+
+        // relative translational velocity
+
+        vrx = v[j][0] - v[i][0];
+        vry = v[j][1] - v[i][1];
+
+        // normal component of the relative translational velocity
+
+        vnnr = vrx*nx + vry*ny;
+
+        // tangential component of the relative translational velocity
+
+        vtx = vrx - vnnr*nx;
+        vty = vry - vnnr*ny;
+
+        // relative rotational velocity
+
+        wrz = (radi*omega[i][2] + radj*omega[j][2]);
+
+        // relative tangential velocity
+
+        vtrx = vtx - ny*wrz;
+        vtry = vty + nx*wrz;
+
+        Pplus  =  -bulkModulus*dtf*vnnr*rinv;
+        Sxplus = -shearModulus*dtf*vtrx*rinv;
+        Syplus = -shearModulus*dtf*vtry*rinv;
+
+        hAVGi = rmass[i]/(rho0*MY_PI*radi*radi);
+        hAVGj = rmass[j]/(rho0*MY_PI*radj*radj);
+
+        hDeltal = 2*MY_PI3*(hAVGi*radi * hAVGj*radj)
+                          /(hAVGi*radi + hAVGj*radj);
+
+//      fx = Pplus*nx*hDeltal;
+//      fy = Pplus*ny*hDeltal;
+        fx = (Pplus*nx + Sxplus)*hDeltal;
+        fy = (Pplus*ny + Syplus)*hDeltal;
+        fz = (Sxplus*ny - Syplus*nx)*hDeltal;
+        
+        f[i][0] -= fx;
+        f[i][1] -= fy;
+        torque[i][2] -= radi*fz;
+
+        if (force->newton_pair || j < atom->nlocal){
+          f[j][0] += fx;
+          f[j][1] += fy;
+          torque[j][2] -= radj*fz;
+        }
+
+      } // end if (Fplus)
+    } // end for (jj = 0; jj < jnum; jj++)
+  } // end for (ii = 0; ii < inum; ii++)
+
+  /*! Put the new velocity into vn for fix_nve_sphere_demsi::integrate_final.
+      Recall that fix_nve_sphere_demsi:integrate_initial has put the explicit
+      part of the update into {v[0,1],omega[2]}. */
+  for (int i = 0; i < nlocal; i++) {
+//  if (mask[i] & groupbit) {
+
+      vn[i][0] =     v[i][0] + dtv*     f[i][0]/rmass[i];
+      vn[i][1] =     v[i][1] + dtv*     f[i][1]/rmass[i];
+      vn[i][2] = omega[i][2] + dtv*torque[i][2]/(0.5*rmass[i]*radi*radi);
+
+//  }
+  } // end for (int i = 0; i < nlocal; i++)
+} // end PairGranRate::compute_rate_explicit
+/* ---------------------------------------------------------------------- */
+
+void PairGranRate::compute_rate_implicit()
+{
+  int i,j,ii,jj,inum,jnum;
+  int itype,jtype;
+
+  int *ilist,*jlist,*numneigh,**firstneigh;
+  int **firsttouch;
+  double *history,*allhistory,**firsthistory;
+  
+  inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  firsttouch = fix_history->firstflag;
+  firsthistory = fix_history->firstvalue;
+  
+  double **x = atom->x;
+  double **v = atom->v;
+  double **f = atom->f;
+  double **vn = atom->vn;
+  double **omega = atom->omega;
+  double **torque = atom->torque;
+  double *radius = atom->radius;
+  double *rmass = atom->rmass;
+  int *type = atom->type;
+  int *mask = atom->mask;
+  int nlocal = atom->nlocal;
+ 
+  auto ns = new int[inum]; // number of neighbors "in contact" with [i]
+  auto ls = new int[inum][6]; // list of [j] in the [i] block
+  auto vs = new double[inum][6][3]; // [i][j] block velocity
+ 
+//if (igroup == atom->firstgroup) nlocal = atom->nfirst;
+
+  int bondFlagIn; // incoming bondFlag
+  int Fplus;      // outgoing bondFlag
+
+  double delx, dely, rsq, radsum;
+  double radi, radj, r, rinv, nx, ny;
+  double vrx, vry, vnnr, vtx, vty, wrz, vtrx, vtry;
+  double hAVGi, hAVGj, hDeltal;
+  double fx, fy, fz;
+  double Pplus, Sxplus, Syplus; // outgoing Pressure, ShearStresses
+  double SYield;  // shear yield conditions
+
+  int historyupdate = 1;
+  if (update->setupflag) historyupdate = 0;
+
+  double dtv = update->dt;
+  double dtf = 0.5 * update->dt; // * force->ftm2v;
+
+  /* Load the explicit force/torque */
+  
+  for (ii = 0; ii < inum; ii++) {
+    i = ilist[ii];
+    f[i][0] = 0.0;
+    f[i][1] = 0.0;
+    torque[i][2] = 0.0;
+  }
+  
+  for (ii = 0; ii < inum; ii++) {
+    i = ilist[ii];
+    itype = atom->type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+    allhistory = firsthistory[i];
+    radi = radius[i];
+
+    // loop over neighbors of each element
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      jtype = atom->type[j];
+      j &= NEIGHMASK;
+      radj = radius[j];
+
+//    *touch = &firsttouch[i][jj];
+      history = &allhistory[size_history*jj];
+
+      /*'history' now points to the ii-jj array that stores
+         all the history associated with pair ii-jj
+         For all pairs:
+         *history[0]: bondPressure
+         *history[1]: bondShearX
+         *history[2]: bondShearY
+         *history[3]: bondFlag [0=no bond, 1=bonded]]
+      */
+
+//    delx = x[i][0] - x[j][0]; // hooke form uses inward normal relative to [i]
+//    dely = x[i][1] - x[j][1];
+      delx = x[j][0] - x[i][0]; // rate form uses outward normal relative to [i]
+      dely = x[j][1] - x[i][1];
+      rsq = delx*delx + dely*dely;
+//    radsum = OverLap*(radius[i] + radius[j]);
+      radsum = 1.01*(radi + radj);
+
+      bondFlagIn = int(history[3]);
+      Fplus = bondFlagIn;
+
+      if(!bondFlagIn){
+        if (rsq >= radsum*radsum){ // no contact
+          firsttouch[i][jj] = 0;
+          Fplus = 0;
+          Pplus = 0.;
+          Sxplus = 0.;
+          Syplus = 0.;
+          fx = fy = fz = 0.;
+        } else { // in first contact
+          firsttouch[i][jj] = 1;
+          Fplus = 1;
+        } // end if(rsq >= radsum*radsum
+        history[0] = history[1] = history[2] = 0.;
+      } // end if(!bondFlagIn)
+
+      if (Fplus){
+        r = sqrt(rsq);
+        rinv = 1.0/r;
+        nx = delx*rinv;
+        ny = dely*rinv;
+
+        // relative translational velocity
+
+        vrx = v[j][0] - v[i][0];
+        vry = v[j][1] - v[i][1];
+
+        // normal component of the relative translational velocity
+
+        vnnr = vrx*nx + vry*ny;
+
+        // tangential component of the relative translational velocity
+
+        vtx = vrx - vnnr*nx;
+        vty = vry - vnnr*ny;
+
+        // relative rotational velocity
+
+        wrz = (radi*omega[i][2] + radj*omega[j][2]);
+
+        // relative tangential velocity
+
+        vtrx = vtx - ny*wrz;
+        vtry = vty + nx*wrz;
+
+        Pplus  =  -bulkModulus*dtf*vnnr*rinv;
+        Sxplus = -shearModulus*dtf*vtrx*rinv;
+        Syplus = -shearModulus*dtf*vtry*rinv;
+
+        hAVGi = rmass[i]/(rho0*MY_PI*radi*radi);
+        hAVGj = rmass[j]/(rho0*MY_PI*radj*radj);
+
+        hDeltal = 2*MY_PI3*(hAVGi*radi * hAVGj*radj)
+                          /(hAVGi*radi + hAVGj*radj);
+
+//      fx = Pplus*nx*hDeltal;
+//      fy = Pplus*ny*hDeltal;
+        fx = (Pplus*nx + Sxplus)*hDeltal;
+        fy = (Pplus*ny + Syplus)*hDeltal;
+        fz = (Sxplus*ny - Syplus*nx)*hDeltal;
+        
+        f[i][0] -= fx;
+        f[i][1] -= fy;
+        torque[i][2] -= radi*fz;
+
+        if (force->newton_pair || j < atom->nlocal){
+          f[j][0] += fx;
+          f[j][1] += fy;
+          torque[j][2] -= radj*fz;
+        }
+
+      } // end if (Fplus)
+    } // end for (jj = 0; jj < jnum; jj++)
+  } // end for (ii = 0; ii < inum; ii++)
+
+  /*! Put the new velocity into vn for fix_nve_sphere_demsi::integrate_final.
+      Recall that fix_nve_sphere_demsi:integrate_initial has put the explicit
+      part of the update into {v[0,1],omega[2]}. */
+  for (int i = 0; i < nlocal; i++) {
+//  if (mask[i] & groupbit) {
+
+      vn[i][0] =     v[i][0] + dtv*     f[i][0]/rmass[i];
+      vn[i][1] =     v[i][1] + dtv*     f[i][1]/rmass[i];
+      vn[i][2] = omega[i][2] + dtv*torque[i][2]/(0.5*rmass[i]*radi*radi);
+
+//  }
+  } // end for (int i = 0; i < nlocal; i++)
+/*
+  Just for practice, load ns and the arrays ls and vs.
+*/
+
+  for (ii = 0; ii < inum; ii++) {
+    i = ilist[ii];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+    allhistory = firsthistory[i];
+    
+    ls[ii][0] = i;
+    ns[ii] = 1; // number of elements in the block
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      history = &allhistory[size_history*jj];
+      
+      if (history[3]) { // the neighbor is "in contact"
+        if(ns[ii]+1 > 7) break; // should never happen, but we need to check...
+        ls[ii][jj] = j;
+        vs[ii][jj][0] = vn[j][0]; // or v[j][0];
+        vs[ii][jj][1] = vn[j][1]; // or v[j][1];
+        vs[ii][jj][2] = vn[j][2]; // or omega[j][2];
+        ns[ii] += 1;
+      }
+    } // end for (jj = 0; jj < jnum; jj++)
+  } // end for (ii = 0; ii < inum; ii++)
+
+  delete[] ns;
+  delete[] ls;
+  delete[] vs;
+  
+} // end PairGranRate::compute_rate_implicit
+/* ---------------------------------------------------------------------- */
+
+void PairGranRate::back_substitute()
+{
+  int i,j,ii,jj,inum,jnum;
+  int itype,jtype;
+
+  int *ilist,*jlist,*numneigh,**firstneigh;
+  int **firsttouch;
+  double *history,*allhistory,**firsthistory;
+  
+  inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  firsttouch = fix_history->firstflag;
+  firsthistory = fix_history->firstvalue;
+  
+  double **x = atom->x;
+  double **v = atom->v;
+  double **f = atom->f;
+  double **vn = atom->vn;
+  double **omega = atom->omega;
+  double **torque = atom->torque;
+  double *radius = atom->radius;
+  double *rmass = atom->rmass;
+  int *type = atom->type;
+  int *mask = atom->mask;
+  int nlocal = atom->nlocal;
+
+//if (igroup == atom->firstgroup) nlocal = atom->nfirst;
+
+  int bondFlagIn; // incoming bondFlag
+  int Fplus;      // outgoing bondFlag
+
+  double delx, dely, rsq, radsum;
+  double radi, radj, r, rinv, nx, ny;
+  double vrx, vry, vnnr, vtx, vty, wrz, vtrx, vtry;
+  double hAVGi, hAVGj, hDeltal;
+  double fx, fy, fz;
+  double Pplus, Sxplus, Syplus; // outgoing Pressure, ShearStresses
+  double SYield;  // shear yield conditions
+
+  int historyupdate = 1;
+  if (update->setupflag) historyupdate = 0;
+
+  double dtv = update->dt;
+  double dtf = 0.5 * update->dt; // * force->ftm2v;
+
+  /* Load the force/torque */
+
+  for (ii = 0; ii < inum; ii++) {
+    i = ilist[ii];
+    f[i][0] = 0.0;
+    f[i][1] = 0.0;
+    torque[i][2] = 0.0;
+  }
+
+  /* Back-substitute for the stress increments based on vn; update the
+     history stress; and reload the forces/torques for use in the next call
+     to fix_nve_sphere_demsi::integrate_initial */
+
+  for (ii = 0; ii < inum; ii++) {
+    i = ilist[ii];
+    itype = atom->type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+    allhistory = firsthistory[i];
+    radi = radius[i];
+
+    // loop over neighbors of each element
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      jtype = atom->type[j];
+      j &= NEIGHMASK;
+      radj = radius[j];
+
+//    *touch = &firsttouch[i][jj];
+      history = &allhistory[size_history*jj];
+
+      /*'history' now points to the ii-jj array that stores
+         all the history associated with pair ii-jj
+         For all pairs:
+         *history[0]: bondPressure
+         *history[1]: bondShearX
+         *history[2]: bondShearY
+         *history[3]: bondFlag [0=no bond, 1=bonded]]
+      */
+      
+//    delx = x[i][0] - x[j][0]; // hopkins uses inward normal relative to [i]
+//    dely = x[i][1] - x[j][1];
+      delx = x[j][0] - x[i][0]; // rateform uses outward normal relative to [i] ??
+      dely = x[j][1] - x[i][1];
+      rsq = delx*delx + dely*dely;
+//    radsum = OverLap*(radius[i] + radius[j]);
+      radsum = 1.01*(radi + radj);
+
+      bondFlagIn = int(history[3]);
+      Fplus = bondFlagIn;
+
+      if(!bondFlagIn){
+        if (rsq >= radsum*radsum){ // no contact
+          firsttouch[i][jj] = 0;
+          Fplus = 0;
+          Pplus = 0.;
+          Sxplus = 0.;
+          Syplus = 0.;
+          fx = fy = fz = 0.;
+        } else { // in first contact
+          firsttouch[i][jj] = 1;
+          Fplus = 1;
+        } // end if(rsq >= radsum*radsum
+        history[0] = history[1] = history[2] = 0.;
+      } // end if(!bondFlagIn)
+
+      if(Fplus){
+        r = sqrt(rsq);
+        rinv = 1.0/r;
+        nx = delx*rinv;
+        ny = dely*rinv;
+
+        // relative translational velocity
+
+        vrx = vn[j][0] - vn[i][0];
+        vry = vn[j][1] - vn[i][1];
+
+        // normal component of the relative translational velocity
+
+        vnnr = vrx*nx + vry*ny;
+
+        // tangential component of the relative translational velocity
+
+        vtx = vrx - vnnr*nx;
+        vty = vry - vnnr*ny;
+
+        // relative rotational velocity
+
+        wrz = (radi*omega[i][2] + radj*omega[j][2]);
+
+        // relative tangential velocity
+
+        vtrx = vtx - ny*wrz;
+        vtry = vty + nx*wrz;
+
+        Pplus  = history[0]  - bulkModulus*dtf*vnnr*rinv;
+        Sxplus = history[1] - shearModulus*dtf*vtrx*rinv;
+        Syplus = history[2] - shearModulus*dtf*vtry*rinv;
+
+      /*! Reload {f,torque} for the next integrate_initial */
+
+        hAVGi = rmass[i]/(rho0*MY_PI*radi*radi);
+        hAVGj = rmass[j]/(rho0*MY_PI*radj*radj);
+
+        hDeltal = 2*MY_PI3*(hAVGi*radi * hAVGj*radj)
+                          /(hAVGi*radi + hAVGj*radj);
+
+//      fx = Pplus*nx*hDeltal;
+//      fy = Pplus*ny*hDeltal;
+        fx = (Pplus*nx + Sxplus)*hDeltal;
+        fy = (Pplus*ny + Syplus)*hDeltal;
+        fz = (Sxplus*ny - Syplus*nx)*hDeltal;
+
+        f[i][0] -= fx;
+        f[i][1] -= fy;
+        torque[i][2] -= radi*fz;
+
+        if (force->newton_pair || j < atom->nlocal){
+          f[j][0] += fx;
+          f[j][1] += fy;
+          torque[j][2] -= radj*fz;
+        }
+
+        // test for tensile fracture, compressive flowstress, shear flowstress
+
+        if (Pplus <= tensileFractureStress) { // tensile fracture
+          Pplus = 0.;
+          Fplus = 0;
+        } else if (Pplus > compressiveYieldStress) { // perfectly plastic compressive flowstress
+          Pplus = compressiveYieldStress;
+        }
+        SYield = sqrt(Sxplus*Sxplus + Syplus*Syplus)/shearYieldStress;
+        if (SYield > 1.0) {
+//          Sxplus /= SYield;
+//          Syplus /= SYield;
+            Sxplus = Syplus = 0.;
+        }
+      } // end if(Fplus)
+      
+      // update history
+      if(historyupdate){
+        history[0] = Pplus;
+        history[1] = Sxplus;
+        history[2] = Syplus;
+        history[3] = double(Fplus);
+      }
+
+      if (evflag) ev_tally_xyz(i,j,atom->nlocal, force->newton_pair,
+              0.0,0.0,fx,fy,0,x[i][0]-x[j][0],x[i][1]-x[j][1],0);
+
+    } // end for (ii = 0; ii < inum; ii++)
+  } // end for (ii = 0; ii < inum; ii++)
+} // end PairGranRate::back_substitute()
+
+/* ----------------------------------------------------------------------
+   global settings
+   ------------------------------------------------------------------------- */
+
+void PairGranRate::settings(int narg, char **arg)
+{
+  if (narg != 7) error->all(FLERR,"Illegal pair_style command");
+             bulkModulus = force->numeric(FLERR, arg[0]);
+            shearModulus = force->numeric(FLERR, arg[1]);
+        shearYieldStress = force->numeric(FLERR, arg[2]);
+  compressiveYieldStress = force->numeric(FLERR, arg[3]);
+   tensileFractureStress = force->numeric(FLERR, arg[4]);
+     timeIntegrationFlag = force->numeric(FLERR, arg[5]);
+                 bulkCFL = force->numeric(FLERR, arg[6]);
+}
+
+/* ---------------------------------------------------------------------- */
+double PairGranRate::init_one(int i, int j)
+{
+  double cutoff;
+  cutoff = PairGranHookeHistory::init_one(i, j);
+  cutoff += maxrad_dynamic[i]*0.1; //This could be an input parameter?
+  return cutoff;
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairGranRate::single(int i, int j, int itype, int jtype,
+    double rsq,
+    double factor_coul, double factor_lj,
+    double &fforce)
+{
+  return 0.0;
+}
+
+/* ---------------------------------------------------------------------- */
+void PairGranRate::transfer_history(double* sourcevalues, double* targetvalues){
+    for (int k = 0; k < size_history; k++){
+      targetvalues[k] = sourcevalues[k];
+    }
+};

--- a/src/USER-DEMSI/pair_gran_rate.cpp
+++ b/src/USER-DEMSI/pair_gran_rate.cpp
@@ -38,9 +38,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-#define DEBUGID_1 35
-#define DEBUGID_2 55
-#define DEBUG_TIMESTEP 32696
 /* ---------------------------------------------------------------------- */
 
 PairGranRate::PairGranRate(LAMMPS *lmp) :
@@ -944,13 +941,13 @@ void PairGranRate::back_substitute()
 void PairGranRate::settings(int narg, char **arg)
 {
   if (narg != 7) error->all(FLERR,"Illegal pair_style command");
-             bulkModulus = force->numeric(FLERR, arg[0]);
-            shearModulus = force->numeric(FLERR, arg[1]);
-        shearYieldStress = force->numeric(FLERR, arg[2]);
-  compressiveYieldStress = force->numeric(FLERR, arg[3]);
-   tensileFractureStress = force->numeric(FLERR, arg[4]);
-     timeIntegrationFlag = force->numeric(FLERR, arg[5]);
-                 bulkCFL = force->numeric(FLERR, arg[6]);
+             bulkModulus = utils::numeric(FLERR, arg[0],false,lmp);
+            shearModulus = utils::numeric(FLERR, arg[1],false,lmp);
+        shearYieldStress = utils::numeric(FLERR, arg[2],false,lmp);
+  compressiveYieldStress = utils::numeric(FLERR, arg[3],false,lmp);
+   tensileFractureStress = utils::numeric(FLERR, arg[4],false,lmp);
+     timeIntegrationFlag = utils::numeric(FLERR, arg[5],false,lmp);
+                 bulkCFL = utils::numeric(FLERR, arg[6],false,lmp);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-DEMSI/pair_gran_rate.h
+++ b/src/USER-DEMSI/pair_gran_rate.h
@@ -37,7 +37,7 @@ protected:
   void compute_rate_exverlet();
   void compute_rate_explicit();
   void compute_rate_implicit();
-  void back_substitute();
+  void load_new_forces();
 
   void allocate();
 

--- a/src/USER-DEMSI/pair_gran_rate.h
+++ b/src/USER-DEMSI/pair_gran_rate.h
@@ -1,0 +1,87 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under 
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+
+PairStyle(gran/rate,PairGranRate)
+
+#else
+
+#ifndef LMP_PAIR_GRAN_RATE_H
+#define LMP_PAIR_GRAN_RATE_H
+
+#include "pair_gran_hooke_history.h"
+
+namespace LAMMPS_NS {
+
+class PairGranRate : public PairGranHookeHistory {
+public:
+  PairGranRate(class LAMMPS *);
+  virtual ~PairGranRate();
+  virtual void compute(int, int);
+  void settings(int, char **);
+  double single(int, int, int, int, double, double, double, double &);
+  virtual void transfer_history(double*, double*);
+  double init_one(int, int);
+protected:
+  void compute_rate_exverlet();
+  void compute_rate_explicit();
+  void compute_rate_implicit();
+  void back_substitute();
+
+  void allocate();
+
+  int history_ndim;
+
+  double  bulkModulus;
+  double shearModulus;
+  double       shearYieldStress;
+  double compressiveYieldStress;
+  double  tensileFractureStress;
+  double timeIntegrationFlag;
+  double bulkCFL;
+  
+/*! math_const.h
+  static const double THIRD  = 1.0/3.0;
+  static const double TWOTHIRDS  = 2.0/3.0;
+  static const double MY_PI  = 3.14159265358979323846; // pi
+  static const double MY_2PI = 6.28318530717958647692; // 2pi
+  static const double MY_3PI = 9.42477796076937971538; // 3pi
+  static const double MY_4PI = 12.56637061435917295384; // 4pi
+  static const double MY_PI2 = 1.57079632679489661923; // pi/2
+  static const double MY_PI4 = 0.78539816339744830962; // pi/4
+  static const double MY_PIS = 1.77245385090551602729; // sqrt(pi)
+  static const double MY_ISPI4 = 1.12837916709551257389; // 1/sqrt(pi/4)
+  static const double MY_SQRT2 = 1.41421356237309504880; // sqrt(2)
+  static const double MY_CBRT2 = 1.25992104989487316476; // 2*(1/3)
+*/
+  const double OverLap = 1.050075135808664;   // R^\prime/R = \sqrt(2\sqrt(3) \slash \pi)
+  const double LapOver = 0.9523128068639574;  // R/R^\prime = \sqrt(\pi \slash 2\sqrt(3))
+  const double rho0 = 950.;  // kg/m^3
+  const double MY_PI3 = 1.0471975511965976; // pi/3
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+ */

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -214,6 +214,7 @@ Atom::Atom(LAMMPS *lmp) : Pointers(lmp)
   coriolis = nullptr;
   ocean_vel = nullptr;
   bvector = nullptr;
+  vn = nullptr; // adding vn
 
   // end of customization section
   // --------------------------------------------------------------------

--- a/src/atom.h
+++ b/src/atom.h
@@ -172,6 +172,7 @@ class Atom : protected Pointers {
   double *coriolis;
   double **ocean_vel;
   double **bvector;
+  double **vn; // adding vn
 
   // end of customization section
   // --------------------------------------------------------------------

--- a/src/atom_vec.h
+++ b/src/atom_vec.h
@@ -180,7 +180,7 @@ class AtomVec : protected Pointers {
   tagint *tag;                 // peratom fields common to all styles
   int *type,*mask;
   imageint *image;
-  double **x,**v,**f;
+  double **x,**v,**f,**vn; // adding vn
 
   // standard list of peratom fields always operated on by different methods
   // common to all styles, so not listed in field strings


### PR DESCRIPTION
**Summary**

In this we add a new contactType, in which the forces depend on the velocities rather than on displacements.  This provides a foundation for a locally implicit force calculation which is, in principle, stable for any value of the time step.  To accomplish this goal, the atom is modified to carry a new variable called 'vn' which is used in the implicit form of the time integration algorithm.  The value of vn is initialized in compute::integrate_initial.  The force calculation in pair_gran_rate then modifies vn and returns the new (updated) value of velocity for use in compute::integrate_final;  pair_gran_rate also computes the forces that correspond to the updated velocity.  Accordingly, the value of vn must be communicated both forward (to pair_gran_rate) and in reverse (from pair_gran_rate).

**Related Issues**

none

**Author(s)**

B. A. Kashiwa and A. K. Turner, LANL.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

The updates are backward compatible.

**Implementation Notes**

Please see the notes in LA-UR-21-23623 for a detailed description of the implicit algorithm.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

none.


