### PR TITLE
Fix bug with constant compressive and tensile breaking stress

### DIFF
--- a/src/KOKKOS/pair_gran_hopkins_kokkos.cpp
+++ b/src/KOKKOS/pair_gran_hopkins_kokkos.cpp
@@ -999,7 +999,7 @@ void PairGranHopkinsKokkos<DeviceType>::compute_bonded_kokkos(int i, int j, int 
     F_FLOAT c1, c2;
     c1 = d_firsthistory(i,size_history*jj);
     c2 = d_firsthistory(i,size_history*jj+1);
-    update_chi(kn0, kt0, Dn, Cn, Dt, Ct, hmin, c1, c2);
+    update_chi(kn0, kt0, Dn, Cn, Dt, Ct, hmin, d_firsthistory(i,size_history*jj+11), c1, c2);
     d_firsthistory(i,size_history*jj) = c1;
     d_firsthistory(i,size_history*jj+1) = c2;
     d_firsttouch(i,jj) = 1;
@@ -1019,8 +1019,15 @@ void PairGranHopkinsKokkos<DeviceType>::compute_bonded_kokkos(int i, int j, int 
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PairGranHopkinsKokkos<DeviceType>::update_chi(F_FLOAT kn0, F_FLOAT kt0, F_FLOAT Dn, F_FLOAT Cn, 
-                                                   F_FLOAT Dt, F_FLOAT Ct, F_FLOAT hmin, F_FLOAT &chi1, 
+void PairGranHopkinsKokkos<DeviceType>::update_chi(F_FLOAT kn0,
+                                                   F_FLOAT kt0,
+                                                   F_FLOAT Dn,
+                                                   F_FLOAT Cn,
+                                                   F_FLOAT Dt,
+                                                   F_FLOAT Ct,
+                                                   F_FLOAT hmin,
+                                                   F_FLOAT bondThickness,
+                                                   F_FLOAT &chi1,
                                                    F_FLOAT &chi2) const
 { 
   F_FLOAT sig_n1 = kn0*(Dn + Cn*chi1);
@@ -1031,14 +1038,14 @@ void PairGranHopkinsKokkos<DeviceType>::update_chi(F_FLOAT kn0, F_FLOAT kt0, F_F
   // function pointers for greater efficiency?
   F_FLOAT sig_c;
   if (strcmp_sig_c0_type_constant) {
-    sig_c = sig_c0;
+    sig_c = sig_c0 * bondThickness;
   } else if (strcmp_sig_c0_type_KovacsSodhi) {
     sig_c = sig_c0*pow(hmin,(2.0/3.0)) * 1000.0;
   } // else error case already handled previously
 
   F_FLOAT sig_t;
   if (strcmp_sig_t0_type_constant) {
-    sig_t = sig_t0;
+    sig_t = sig_t0 * bondThickness;
   } else if (strcmp_sig_t0_type_multiply_sig_c0) {
     sig_t = sig_t0 * sig_c;
   } // else error case already handled previously

--- a/src/KOKKOS/pair_gran_hopkins_kokkos.h
+++ b/src/KOKKOS/pair_gran_hopkins_kokkos.h
@@ -61,8 +61,15 @@ class PairGranHopkinsKokkos : public PairGranHopkins {
 	                     F_FLOAT &torque_i, F_FLOAT &torque_j) const;
 
   KOKKOS_INLINE_FUNCTION
-  void update_chi(F_FLOAT kn0, F_FLOAT kt0, F_FLOAT Dn, F_FLOAT Cn,
-                  F_FLOAT Dt, F_FLOAT Ct, F_FLOAT hmin, F_FLOAT &chi1,
+  void update_chi(F_FLOAT kn0,
+                  F_FLOAT kt0,
+                  F_FLOAT Dn,
+                  F_FLOAT Cn,
+                  F_FLOAT Dt,
+                  F_FLOAT Ct,
+                  F_FLOAT hmin,
+                  F_FLOAT bondThickness,
+                  F_FLOAT &chi1,
                   F_FLOAT &chi2) const;
 
   template<int NEWTON_PAIR>


### PR DESCRIPTION
Constant compressive and tensile breaking stress needed to be multiplied by bond thickness

**Summary**

Constant compressive and tensile breaking stress configs are now multiplied by bond thickness to get the correct units

**Author(s)**

A. K. Turner (LANL)

**Backward Compatibility**

Not BFB only for simulations using constant compressive and tensile breaking stress configs


