### PR TITLE
Turn on single_bond method for Hopkins contact model for CPUs

### DIFF
--- a/src/KOKKOS/pair_gran_hopkins_kokkos.cpp
+++ b/src/KOKKOS/pair_gran_hopkins_kokkos.cpp
@@ -382,10 +382,10 @@ void PairGranHopkinsKokkos<DeviceType>::operator()(TagPairGranHopkinsCompute<NEI
 }
 
 //-----------------------------------------------------------------------------
-
+#ifndef KOKKOS_ENABLE_CUDA
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PairGranHopkinsKokkos<DeviceType>::demsi_single_bond(int i,
+void PairGranHopkinsKokkos<DeviceType>::single_bond(int i,
 						    int j,
 						    int jj,
 						    F_FLOAT &fx,
@@ -432,7 +432,7 @@ void PairGranHopkinsKokkos<DeviceType>::demsi_single_bond(int i,
   }
 
 }
-
+#endif
 //-----------------------------------------------------------------------------
 
 template<class DeviceType>

--- a/src/KOKKOS/pair_gran_hopkins_kokkos.h
+++ b/src/KOKKOS/pair_gran_hopkins_kokkos.h
@@ -50,8 +50,9 @@ class PairGranHopkinsKokkos : public PairGranHopkins {
   KOKKOS_INLINE_FUNCTION
   void operator()(TagPairGranHopkinsCompute<NEIGHFLAG,NEWTON_PAIR,HISTORYUPDATE,EVFLAG>, const int, EV_FLOAT &ev) const;
 
+#ifndef KOKKOS_ENABLE_CUDA
   KOKKOS_INLINE_FUNCTION
-  void demsi_single_bond(int,
+  void single_bond(int,
 		   int,
 		   int,
 		   F_FLOAT &fx,
@@ -62,6 +63,7 @@ class PairGranHopkinsKokkos : public PairGranHopkins {
 		   F_FLOAT &fyt,
 		   F_FLOAT &torque_i,
 		   F_FLOAT &torque_j);
+#endif
 
   template<int NEIGHFLAG, int NEWTON_PAIR, int HISTORYUPDATE>
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
**Summary**

With a preprocessor ifdef statement turn compute_single method in Hopkins contact model on for CPU and off for GPU

**Author(s)**
A. K. Turner

